### PR TITLE
warn if KustoCluster does not contain //ingest-, cleanup SaveConfiguration to remove Schema and prepended table names.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,7 +115,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.event.repository.name }}-${{ github.sha }}
-          release_name: ${{ github.event.repository.name }}
+          release_name: ${{ env.project_name }}
           draft: false
           prerelease: false
 

--- a/CollectSFData/Common/ConfigurationOptions.cs
+++ b/CollectSFData/Common/ConfigurationOptions.cs
@@ -353,9 +353,22 @@ namespace CollectSFData
 
         public void SaveConfigFile()
         {
+            string kustoTable = KustoTable;
+            string logAnalyticsName = LogAnalyticsName;
+
             if (string.IsNullOrEmpty(SaveConfiguration))
             {
                 return;
+            }
+
+            if (IsKustoConfigured())
+            {
+                KustoTable = Regex.Replace(KustoTable, $"^{GatherType}_", "");
+            }
+
+            if (IsLogAnalyticsConfigured())
+            {
+                LogAnalyticsName = Regex.Replace(LogAnalyticsName, $"^{GatherType}_", "");
             }
 
             // remove options that should not be saved in configuration file
@@ -373,6 +386,16 @@ namespace CollectSFData
             if (!IsCacheLocationPreConfigured())
             {
                 options.Remove("CacheLocation");
+            }
+
+            if (IsKustoConfigured())
+            {
+                KustoTable = kustoTable;
+            }
+
+            if (IsLogAnalyticsConfigured())
+            {
+                LogAnalyticsName = logAnalyticsName;
             }
 
             Log.Info($"options results:", options);
@@ -711,6 +734,11 @@ namespace CollectSFData
                 if (IsKustoPurgeRequested())
                 {
                     retval = IsKustoConfigured();
+                }
+
+                if (!KustoCluster.ToLower().Contains("//ingest-"))
+                {
+                    Log.Warning($"KustoCluster url does not contain 'ingest-' {KustoCluster}");
                 }
             }
 

--- a/CollectSFData/Common/ConfigurationOptions.cs
+++ b/CollectSFData/Common/ConfigurationOptions.cs
@@ -358,9 +358,10 @@ namespace CollectSFData
                 return;
             }
 
-            // remove options that shouldnt be in saved in file
+            // remove options that should not be saved in configuration file
             JObject options = JObject.FromObject(this);
             options.AddFirst(new JProperty("$schema", SchemaFile));
+            options.Remove("Schema");
             options.Remove("ConfigurationFile");
             options.Remove("EndTimeUtc");
             options.Remove("Examples");


### PR DESCRIPTION
warn if KustoCluster does not contain //ingest-
cleanup SaveConfiguration to remove Schema and prepended table names.