### PR TITLE
fix regex pattern for double quote

### DIFF
--- a/CollectSFData/Kusto/KustoConnection.cs
+++ b/CollectSFData/Kusto/KustoConnection.cs
@@ -390,7 +390,7 @@ namespace CollectSFData.Kusto
 
                 if (results.Any())
                 {
-                    Regex pattern = new Regex(@"''resourceId'': ''(/[A-Za-z0-9./-]+)''");
+                    Regex pattern = new Regex(@"resourceId\W+?(/[A-Za-z0-9./-]+)");
                     Match match = pattern.Match(results.FirstOrDefault());
                     Config.ResourceUri = match.Groups[1].Value;
                     Log.Info($"ResourceID: {Config.ResourceUri}");


### PR DESCRIPTION
regex pattern with two single quotes failing

issue:
results
Count = 1
    [0]: "7/16/2020 9:04:43 AM,Informational,6356,6888,InfrastructureService.RestClientHelper,RequestUri: 'https://eastus.servicefabric.azure.com/runtime/clusters/{{cluster id}}?api-version=6.5', Status: 'OK', ReasonPhrase: 'OK', CertificateThumbprint: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, CertificateSubject: CN=sfjagilber CorrelationId: a3c3d274-5f55-48f4-b10a-778b8a6f61ca.\r\t Content: {\r\t  \"clusterOperationDescription\": {\r\t    \"resourceId\": \"/subscriptions/{{subscription id}}/resourcegroups/{{resource group name}}/providers/Microsoft.ServiceFabric/clusters/{{cluster name}}\",\r\t    \"resourceType\": \"Cluster\",\r\t    \"operationType\": \"CreateOrUpdate\",\r\t    \"operationSequenceNumber\": 1,\r\t    \"processedNodesStatus\": [],\r\t    \"primaryNodeTypes\": [\r\t      \"nt0\"\r\t    ]\r\t  },\r\t  \"applicationTypeOperationDescriptions\": [],\r\t  \"applicationOperationDescriptions\": [],\r\t  \"serviceOperationDescriptions\": []\r\t}

pattern
{''resourceId'': ''(/[A-Za-z0-9./-]+)''}
    CapNames: null
    Caps: null
    MatchTimeout: {-00:00:00.0010000}
    Options: None
    RightToLeft: false
    capnames: null
    caps: null
    capsize: 2
    capslist: null
    factory: null
    internalMatchTimeout: {-00:00:00.0010000}
    pattern: "''resourceId'': ''(/[A-Za-z0-9./-]+)''"
    roptions: None
