### PR TITLE
Jsonformatter / gathertype table fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Change log
+
+## 12/4/2020  
+
+- modify repo layout structure and place source in /src  
+- add kusto functions  
+- fix table ingest only ingesting last chunk enumerated from table  
+- fix unique table ingest when kustoingestmessage false using .set-or-replace  
+- fix table filter now using containerfilter  
+- migrate from binaryformatter deprecated in net5 to newtonsoft json serializer  
+- fix unique when kustoingestmessage false and file is over max ingest size  
+- updated loganalytics api  
+- add tests for msal and kusto  
+- update README  
+- update configuration json examples  
+- add building md  
+
+## 11/10/2020 https://github.com/microsoft/CollectServiceFabricData/tree/v2.7.2011.10013644  
+
+- add labeler workflow back after github fix  
+- migrated from nuget to dotnet build for workflow  
+- add vscode launch.json config  
+- add support for dll and exe. converted project to dll and made new exe project referencing dll project.  
+- clean app.config  
+- migrate to csproj nuget package from packages.config   
+- clean csproj
+- modify nuspec layout to support dll and exe  
+- migrate from .net462 to .net472 for security and stability  
+- add support for .netcoreapp3.1  
+- modify static inherited instance class to singleton reference  
+- migrate from ADAL to MSAL as ADAL is now deprecated  
+- move token cache to userprofile  
+- add object, counter, instance fields for gather type counter  
+- fix temp directory saveconfig in json output  
+- fix custom task scheduler thread race causing duplicate managers
+- migrate from logdebug bool to logdebug int levels 0-5 to turn down logging  
+- update test project to .netcore to remove security vulnerabilities  
+- add kusto functions  
+- add build scripts in /scripts dir  
+
+## 7/30/2020 https://github.com/microsoft/CollectServiceFabricData/tree/v2.6.7516.26434  
+
+- fix nuget package layout
+
+## 7/23/2020 https://github.com/microsoft/CollectServiceFabricData/releases/tag/v2.6.7509.24815  
+
+- remove broken labeler workflow  
+- add nuget package to workflow  
+- set source code namespaces  
+- remove static members from httpclient  
+- add tests  
+- add kusto functions  
+
+## 4/22/2020 https://github.com/microsoft/CollectServiceFabricData/releases/tag/v2.6.7417.39096
+
+- add collectsfdata.options.json to release
+- add discovered blob time range to output
+- add sas validation
+- add noprogresstimeout min to prevent indefinite hang  
+- add online version check  
+- add maxstreamtransmitbytes  
+- add last message list  
+- add determineclusterid fallback 
+- add kustoUseIngestMessage  
+- add admin and query clients to kusto endpoint
+- add test classes  
+- add kusto functions  
+- default kustoCompressed to true  
+- update config schema  
+
+
+## 12/4/2019 https://github.com/microsoft/CollectServiceFabricData/releases/tag/v2.6.7277.26289
+
+- modify git actions for v1 and update tag
+- modify blob callback to include length
+- modify displaystatus summary
+- add config validation functions
+- add gathertype exception
+- add / modify kusto functions
+
+## 11/21/2019 init 2.6 public release  
+
+- .net462 console utility  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - add vscode launch.json config  
 - add support for dll and exe. converted project to dll and created new exe project referencing dll project.  
 - clean app.config  
-- migrate to csproj nuget package from packages.config   
+- migrate to csproj nuget package from packages.config  
 - clean csproj
 - modify nuspec layout to support dll and exe  
 - migrate from .net462 to .net472 for security and stability  
@@ -62,7 +62,7 @@
 - add online version check  
 - add maxstreamtransmitbytes  
 - add last message list  
-- add determineclusterid fallback 
+- add determineclusterid fallback  
 - add kustoUseIngestMessage  
 - add admin and query clients to kusto endpoint
 - add test classes  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@
 - default kustoCompressed to true  
 - update config schema  
 
-
 ## 12/4/2019 https://github.com/microsoft/CollectServiceFabricData/releases/tag/v2.6.7277.26289
 
 - modify git actions for v1 and update tag
@@ -80,6 +79,6 @@
 - add gathertype exception
 - add / modify kusto functions
 
-## 11/21/2019 init 2.6 public release  
+## 11/21/2019 init 2.6 public release https://github.com/microsoft/CollectServiceFabricData/tree/CollectServiceFabricData-c75b19fef60739aebb3707fef556c768bc1432c5
 
 - .net462 console utility  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,32 +3,34 @@
 ## 12/4/2020  
 
 - modify repo layout structure and place source in /src  
+- add .devcontainer with net5 custom install for codespaces  
 - add kusto functions  
 - fix table ingest only ingesting last chunk enumerated from table  
 - fix unique table ingest when kustoingestmessage false using .set-or-replace  
 - fix table filter now using containerfilter  
 - migrate from binaryformatter deprecated in net5 to newtonsoft json serializer  
 - fix unique when kustoingestmessage false and file is over max ingest size  
-- updated loganalytics api  
+- update loganalytics api version  
 - add tests for msal and kusto  
 - update README  
 - update configuration json examples  
 - add building md  
+- add CHANGELOG  
 
 ## 11/10/2020 https://github.com/microsoft/CollectServiceFabricData/tree/v2.7.2011.10013644  
 
-- add labeler workflow back after github fix  
-- migrated from nuget to dotnet build for workflow  
+- add labeler workflow back after github cross fork pr fix  
+- migrate from nuget to dotnet build for workflow  
 - add vscode launch.json config  
-- add support for dll and exe. converted project to dll and made new exe project referencing dll project.  
+- add support for dll and exe. converted project to dll and created new exe project referencing dll project.  
 - clean app.config  
 - migrate to csproj nuget package from packages.config   
 - clean csproj
 - modify nuspec layout to support dll and exe  
 - migrate from .net462 to .net472 for security and stability  
 - add support for .netcoreapp3.1  
-- modify static inherited instance class to singleton reference  
-- migrate from ADAL to MSAL as ADAL is now deprecated  
+- modify static inherited 'instance' class to singleton  
+- migrate from deprecated ADAL to MSAL. tested client, user, and device on windows and ubuntu  
 - move token cache to userprofile  
 - add object, counter, instance fields for gather type counter  
 - fix temp directory saveconfig in json output  

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,8 +6,115 @@ To report issue with collectsfdata, create a new issue in github repo [new issue
 
 ## Building
 
-Visual Studio 2019 with .net 4.7.2 for CollectSFData
-Visual Studio 2019 with .netcoreapp3.1 and powershell 7.0 for CollectSFDataTest
+### CollectSFData / CollectSFDataDll
+
+Visual Studio 2019 with .net 4.7.2 / .netcoreapp3.1 / net5  
+or  
+Visual Studio Code with .net 4.7.2 / .netcoreapp3.1 / net5  
+
+### **launch.json**
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PowerShell Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "cwd": "${file}"
+        },
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/bin/Debug/netcoreapp3.1/CollectSFData.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/bin/Debug/netcoreapp3.1",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}
+```
+
+### commandline
+
+```powershell
+.\dotnet-build.ps1 [[-targetFramework] <string[]>] [[-configuration] <Object>] [[-runtimeIdentifier] <Object>] [[-projectDir] <string>] [[-nugetFallbackFolder] <string>] [-publish] [-clean]
+```
+
+#### **example**
+
+```powershell
+PS C:\github\jagilber\CollectServiceFabricData\scripts> .\dotnet-build.ps1
+current frameworks: netcoreapp3.1;net472
+copying and adding target framework to csproj net5
+saving to C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj
+current frameworks: netcoreapp3.1;net472
+copying and adding target framework to csproj net5
+saving to C:\github\jagilber\CollectServiceFabricData\src\CollectSFDataDll\CollectSFDataDll.temp.csproj
+dotnet restore C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj
+  Determining projects to restore...
+  Restored C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj (in 560 ms).
+  Restored C:\github\jagilber\CollectServiceFabricData\src\CollectSFDataDll\CollectSFDataDll.csproj (in 563 ms).
+dotnet build C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj -c debug
+Microsoft (R) Build Engine version 16.8.0-preview-20451-02+51a1071f8 for .NET
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+  Determining projects to restore...
+  Restored C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj (in 537 ms).
+  Restored C:\github\jagilber\CollectServiceFabricData\src\CollectSFDataDll\CollectSFDataDll.csproj (in 538 ms).
+  CollectSFDataDll -> C:\github\jagilber\CollectServiceFabricData\src\bin\debug\netcoreapp3.1\CollectSFDataDll.dll
+  CollectSFData.temp -> C:\github\jagilber\CollectServiceFabricData\src\bin\debug\net5\CollectSFData.dll
+  Output written to C:\github\jagilber\CollectServiceFabricData\src\bin\debug\net5\
+  Successfully created package 'C:\github\jagilber\CollectServiceFabricData\src\bin\debug\Microsoft.ServiceFabric.CollectSFData.2.7.2012.4151456.nupkg'.
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:02.81
+nuget add C:\github\jagilber\CollectServiceFabricData\src\bin\debug\Microsoft.ServiceFabric.CollectSFData.2.7.2012.4151456.nupkg -source C:\Users\jagilber\.dotnet\NuGetFallbackFolder
+Installing Microsoft.ServiceFabric.CollectSFData 2.7.2012.4151456.
+Successfully added package 'C:\github\jagilber\CollectServiceFabricData\src\bin\debug\Microsoft.ServiceFabric.CollectSFData.2.7.2012.4151456.nupkg' to feed 'C:\Users\jagilber\.dotnet\NuGetFallbackFolder'.
+dotnet build C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj -c release
+Microsoft (R) Build Engine version 16.8.0-preview-20451-02+51a1071f8 for .NET
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+  Determining projects to restore...
+  Restored C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj (in 546 ms).
+  Restored C:\github\jagilber\CollectServiceFabricData\src\CollectSFDataDll\CollectSFDataDll.csproj (in 547 ms).
+  CollectSFDataDll -> C:\github\jagilber\CollectServiceFabricData\src\bin\release\netcoreapp3.1\CollectSFDataDll.dll
+  CollectSFData.temp -> C:\github\jagilber\CollectServiceFabricData\src\bin\release\net5\CollectSFData.dll
+  Output written to C:\github\jagilber\CollectServiceFabricData\src\bin\release\net5\
+  Successfully created package 'C:\github\jagilber\CollectServiceFabricData\src\bin\release\Microsoft.ServiceFabric.CollectSFData.2.7.2012.4151459.nupkg'.
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:02.73
+nuget add C:\github\jagilber\CollectServiceFabricData\src\bin\release\Microsoft.ServiceFabric.CollectSFData.2.7.2012.4151459.nupkg -source C:\Users\jagilber\.dotnet\NuGetFallbackFolder
+Installing Microsoft.ServiceFabric.CollectSFData 2.7.2012.4151459.
+Successfully added package 'C:\github\jagilber\CollectServiceFabricData\src\bin\release\Microsoft.ServiceFabric.CollectSFData.2.7.2012.4151459.nupkg' to feed 'C:\Users\jagilber\.dotnet\NuGetFallbackFolder'.
+removing temp file C:\github\jagilber\CollectServiceFabricData\src\CollectSFData\CollectSFData.temp.csproj
+removing temp file C:\github\jagilber\CollectServiceFabricData\src\CollectSFDataDll\CollectSFDataDll.temp.csproj
+```
+
+### CollectSFDataTest
+
+Visual Studio Code with .netcoreapp3.1 / net5 and powershell 7.0+
+or
+Visual Studio 2019 with .netcoreapp3.1 / net5 and powershell 7.0+
 
 ## Setup
 

--- a/kusto/functions/sftable/TableView.csl
+++ b/kusto/functions/sftable/TableView.csl
@@ -5,7 +5,7 @@
         DistinctEvents
             | join Table on $left.Timestamp==$right.Timestamp and $left.PartitionKey==$right.PartitionKey and $left.RowKey==$right.RowKey
             | extend propertyPack = pack(PropertyName, PropertyValue)
-            | summarize bag = make_bag(propertyPack) by Timestamp, PartitionKey, RowKey, RelativeUri
+            | summarize bag = make_bag(propertyPack) by Timestamp, PartitionKey, RowKey, RelativeUri=trim_end(@'\.?\d?\.table\.csv', RelativeUri)
             | evaluate bag_unpack(bag) 
         | order by Timestamp asc
     }

--- a/src/CollectSFDataDll/Azure/AzureResourceManager.cs
+++ b/src/CollectSFDataDll/Azure/AzureResourceManager.cs
@@ -299,11 +299,7 @@ namespace CollectSFData.Azure
 
         public void MsalLoggerCallback(LogLevel level, string message, bool containsPII)
         {
-            if (!containsPII | (containsPII & Config.LogDebug >= LoggingLevel.Verbose))
-            {
-                Log.Info($"{level} {message.Replace(" [", "\r\n [")}");
-            }
-
+            Log.Debug($"{level} {message.Replace(" [", "\r\n [")}");
             MsalHandler logMessage = MsalMessage;
             logMessage?.Invoke(level, message, containsPII);
         }

--- a/src/CollectSFDataDll/Azure/BlobManager.cs
+++ b/src/CollectSFDataDll/Azure/BlobManager.cs
@@ -23,6 +23,7 @@ namespace CollectSFData.Azure
         private readonly CustomTaskManager _blobTasks = new CustomTaskManager(true);
         private CloudStorageAccount _account;
         private CloudBlobClient _blobClient;
+        private string _fileFilterPattern = @"(?:.+_){6}(\d{20})_";
         private Instance _instance = Instance.Singleton();
         private ConfigurationOptions Config => _instance.Config;
 
@@ -328,9 +329,9 @@ namespace CollectSFData.Azure
 
                 Interlocked.Increment(ref _instance.TotalFilesEnumerated);
 
-                if (Regex.IsMatch(blob.Uri.ToString(), FileFilterPattern, RegexOptions.IgnoreCase))
+                if (Regex.IsMatch(blob.Uri.ToString(), _fileFilterPattern, RegexOptions.IgnoreCase))
                 {
-                    long ticks = Convert.ToInt64(Regex.Match(blob.Uri.ToString(), FileFilterPattern, RegexOptions.IgnoreCase).Groups[1].Value);
+                    long ticks = Convert.ToInt64(Regex.Match(blob.Uri.ToString(), _fileFilterPattern, RegexOptions.IgnoreCase).Groups[1].Value);
 
                     if (ticks < Config.StartTimeUtc.Ticks | ticks > Config.EndTimeUtc.Ticks)
                     {
@@ -343,7 +344,7 @@ namespace CollectSFData.Azure
                 }
                 else
                 {
-                    Log.Debug($"regex not matched: {blob.Uri.ToString()} pattern: {FileFilterPattern}");
+                    Log.Debug($"regex not matched: {blob.Uri.ToString()} pattern: {_fileFilterPattern}");
                 }
 
                 try

--- a/src/CollectSFDataDll/Azure/TableManager.cs
+++ b/src/CollectSFDataDll/Azure/TableManager.cs
@@ -223,7 +223,7 @@ namespace CollectSFData.Azure
                     }
 
                     FileObject fileObject = new FileObject($"{cloudTable.Name}.{chunkCount++}{TableExtension}", Config.CacheLocation);
-                    fileObject.Stream.Write(resultsChunk.ToList());
+                    fileObject.Stream.Write(resultsChunk);
 
                     _instance.TotalFilesDownloaded++;
                     IngestCallback?.Invoke(fileObject);
@@ -268,10 +268,10 @@ namespace CollectSFData.Azure
                         Timestamp = result.Timestamp.UtcDateTime,
                         EventTimeStamp = actualTimeStamp,
                         ETag = result.ETag,
-                        PartitionKey = $"\"{result.PartitionKey}\"",
-                        RowKey = $"\"{result.RowKey}\"",
-                        PropertyName = $"\"{entity.Key}\"",
-                        PropertyValue = $"\"{entity.Value.Replace("\"", "\"\"")}\"",
+                        PartitionKey = result.PartitionKey,
+                        RowKey = result.RowKey,
+                        PropertyName = entity.Key,
+                        PropertyValue = entity.Value,
                         RelativeUri = cloudTable.Name,
                         ResourceUri = Config.ResourceUri
                     });

--- a/src/CollectSFDataDll/Azure/TableManager.cs
+++ b/src/CollectSFDataDll/Azure/TableManager.cs
@@ -220,7 +220,10 @@ namespace CollectSFData.Azure
                         continue;
                     }
 
-                    FileObject fileObject = new FileObject($"{cloudTable.Name}.{chunkCount++}{TableExtension}", Config.CacheLocation);
+                    string relativeUri = $"{Config.StartTimeUtc.Ticks}-{Config.EndTimeUtc.Ticks}-{cloudTable.Name}.{chunkCount++}{TableExtension}";
+                    FileObject fileObject = new FileObject(relativeUri, Config.CacheLocation);
+                    resultsChunk.ToList().ForEach(x => x.RelativeUri = relativeUri);
+                    
                     fileObject.Stream.Write(resultsChunk);
 
                     _instance.TotalFilesDownloaded++;

--- a/src/CollectSFDataDll/Common/ConfigurationOptions.cs
+++ b/src/CollectSFDataDll/Common/ConfigurationOptions.cs
@@ -482,7 +482,7 @@ namespace CollectSFData.Common
                 }
 
                 Log.Info($"setting output location to: {workDirPath}");
-                CacheLocation = workDirPath;
+                CacheLocation = FileManager.NormalizePath(workDirPath);
             }
 
             if (!UseMemoryStream && !CacheLocation.StartsWith("\\\\"))
@@ -737,7 +737,7 @@ namespace CollectSFData.Common
                 try
                 {
                     propertyInstance.SetValue(this, instanceValue);
-                    Log.Info($"set:{propertyInstance.Name}:{thisValue} -> {instanceValue}");
+                    Log.Highlight($"set:{propertyInstance.Name}:{thisValue} -> {instanceValue}");
                 }
                 catch (Exception e)
                 {

--- a/src/CollectSFDataDll/Common/Constants.cs
+++ b/src/CollectSFDataDll/Common/Constants.cs
@@ -23,7 +23,6 @@ namespace CollectSFData.Common
         public static long DiscoveredMinDateTicks = DateTime.MaxValue.Ticks;
         public const string DumpExtension = ".dmp";
         public const string FalseStringPattern = @"(false|0|off|null)";
-        public const string FileFilterPattern = @"(?:.+_){6}(\d{20})_";
         public const string JsonExtension = ".json";
         public const string KustoUrlPattern = "https://(?<ingest>ingest-){1}(?<clusterName>.+?)\\.(?<location>.+?){0,1}\\.(?<domainName>.+?)/(?<databaseName>.+?){1}(/|$)";
         public const string ManagementAzureCom = "https://management.azure.com";

--- a/src/CollectSFDataDll/Common/Constants.cs
+++ b/src/CollectSFDataDll/Common/Constants.cs
@@ -47,6 +47,7 @@ namespace CollectSFData.Common
         public const int ThreadSleepMsWarning = 5000;
         public const string TraceFileExtension = ".dtr";
         public const string TrueStringPattern = @"(true|1|on)";
+        public const int WarningJsonTransmitBytes = (int)(MaxJsonTransmitBytes * .95);
         public const int WarningTimeSpanHours = 4;
         public const double WarningTimeSpanMinHours = .5F;
         public const string ZipExtension = ".zip";

--- a/src/CollectSFDataDll/Common/Log.cs
+++ b/src/CollectSFDataDll/Common/Log.cs
@@ -105,12 +105,12 @@ namespace CollectSFData.Common
             {
                 ConsoleColor color = ConsoleColor.White;
 
-                if (Regex.IsMatch(message, "succeed|success|true", RegexOptions.IgnoreCase))
+                if (Regex.IsMatch(message, "succeed|success|info", RegexOptions.IgnoreCase))
                 {
                     color = ConsoleColor.Green;
                 }
 
-                if (Regex.IsMatch(message, "fail|error|false", RegexOptions.IgnoreCase))
+                if (Regex.IsMatch(message, "fail|error|critical", RegexOptions.IgnoreCase))
                 {
                     color = ConsoleColor.Red;
                 }
@@ -150,7 +150,7 @@ namespace CollectSFData.Common
                                 object jsonSerializer = null,
                                 [CallerMemberName] string callerName = "")
         {
-            if (LogDebug >= LoggingLevel.Error)
+            if (LogDebug >= LoggingLevel.Warning)
             {
                 Process(message, foregroundColor, backgroundColor, jsonSerializer, false, true, callerName: callerName);
             }

--- a/src/CollectSFDataDll/DataFile/CsvCounterRecord.cs
+++ b/src/CollectSFDataDll/DataFile/CsvCounterRecord.cs
@@ -10,7 +10,7 @@ namespace CollectSFData.DataFile
     [Serializable]
     public class CsvCounterRecord : IRecord
     {
-        public string Counter { get; internal set; }
+        public string Counter { get; set; }
 
         public string CounterName { get; set; }
 
@@ -18,11 +18,11 @@ namespace CollectSFData.DataFile
 
         public string FileType { get; set; }
 
-        public string Instance { get; internal set; }
+        public string Instance { get; set; }
 
         public string NodeName { get; set; }
 
-        public string Object { get; internal set; }
+        public string Object { get; set; }
 
         public string RelativeUri { get; set; }
 

--- a/src/CollectSFDataDll/DataFile/FileManager.cs
+++ b/src/CollectSFDataDll/DataFile/FileManager.cs
@@ -60,7 +60,7 @@ namespace CollectSFData.DataFile
                 Log.Info($"downloaded:{fileObject.FileUri}", ConsoleColor.DarkCyan, ConsoleColor.DarkBlue);
             }
 
-            if (fileObject.DownloadAction != null && fileObject.Stream.Get().Length < 1 && !fileObject.Exists)
+            if (fileObject.DownloadAction != null && fileObject.Length < 1 && !fileObject.Exists)
             {
                 string error = $"memoryStream does not exist and file does not exist {fileObject.FileUri}";
                 Log.Error(error);
@@ -69,7 +69,7 @@ namespace CollectSFData.DataFile
 
             if (!fileObject.FileType.Equals(FileTypesEnum.any))
             {
-                if (fileObject.Stream.Get().Length < 1 & fileObject.Exists)
+                if (fileObject.Length < 1 & fileObject.Exists)
                 {
                     // for cached directory uploads
                     fileObject.Stream.ReadFromFile();
@@ -248,9 +248,9 @@ namespace CollectSFData.DataFile
                                         Timestamp = Convert.ToDateTime(counterValues[0].Trim('"').Trim(' ')),
                                         CounterName = headers[headerIndex],
                                         CounterValue = Decimal.Parse(stringValue, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint),
-                                        Object = counterInfo.Groups["object"].Value.Replace("\"","").Trim(),
-                                        Counter = counterInfo.Groups["counter"].Value.Replace("\"","").Trim(),
-                                        Instance = counterInfo.Groups["instance"].Value.Replace("\"","").Trim().Trim('(').Trim(')'),
+                                        Object = counterInfo.Groups["object"].Value.Replace("\"", "").Trim(),
+                                        Counter = counterInfo.Groups["counter"].Value.Replace("\"", "").Trim(),
+                                        Instance = counterInfo.Groups["instance"].Value.Replace("\"", "").Trim().Trim('(').Trim(')'),
                                         NodeName = fileObject.NodeName,
                                         FileType = fileObject.FileDataType.ToString(),
                                         RelativeUri = fileObject.RelativeUri
@@ -278,9 +278,9 @@ namespace CollectSFData.DataFile
         {
             Log.Debug($"enter:{fileObject.FileUri}");
             fileObject.FileUri = RelogBlg(fileObject);
-            IList<CsvCounterRecord> records = ExtractPerfCsvData(fileObject);
+            fileObject.Stream.Write<CsvCounterRecord>(ExtractPerfCsvData(fileObject));
 
-            return PopulateCollection(fileObject, records);
+            return PopulateCollection<CsvCounterRecord>(fileObject);
         }
 
         private FileObjectCollection FormatDtrFile(FileObject fileObject)
@@ -297,7 +297,8 @@ namespace CollectSFData.DataFile
             };
 
             Log.Last($"{fileObject.LastModified} {fileObject.FileUri}{Config.SasEndpointInfo.SasToken}", ConsoleColor.Cyan);
-            return PopulateCollection(fileObject, records);
+            fileObject.Stream.Write(records);
+            return PopulateCollection<CsvExceptionRecord>(fileObject);
         }
 
         private FileObjectCollection FormatSetupFile(FileObject fileObject)
@@ -308,9 +309,7 @@ namespace CollectSFData.DataFile
         private FileObjectCollection FormatTableFile(FileObject fileObject)
         {
             Log.Debug($"enter:{fileObject.FileUri}");
-            IList<CsvTableRecord> records = fileObject.Stream.Read<CsvTableRecord>();
-
-            return PopulateCollection(fileObject, records);
+            return PopulateCollection<CsvTableRecord>(fileObject);
         }
 
         private FileObjectCollection FormatTraceFile<T>(FileObject fileObject) where T : ITraceRecord, new()
@@ -347,7 +346,10 @@ namespace CollectSFData.DataFile
                 }
 
                 Log.Debug($"finished format:{fileObject.FileUri}");
-                return PopulateCollection(fileObject, records.Cast<IRecord>().ToList());
+            
+                fileObject.Stream.ResetPosition();
+                fileObject.Stream.Write(records);
+                return PopulateCollection<DtrTraceRecord>(fileObject);
             }
             catch (Exception e)
             {
@@ -356,18 +358,18 @@ namespace CollectSFData.DataFile
             }
         }
 
-        private FileObjectCollection PopulateCollection<T>(FileObject fileObject, IList<T> records) where T : IRecord
+        private FileObjectCollection PopulateCollection<T>(FileObject fileObject)
         {
             FileObjectCollection collection = new FileObjectCollection() { fileObject };
             _instance.TotalFilesFormatted++;
-            _instance.TotalRecords += records.Count;
+            _instance.TotalRecords += fileObject.RecordCount;
 
             if (Config.IsKustoConfigured())
             {
                 // kusto native format is Csv
                 // kusto json ingest is 2 to 3 times slower and does *not* use standard json format. uses json document per line no comma
                 // using csv and compression for best performance
-                collection = SerializeCsv(fileObject, records);
+                collection = SerializeCsv<T>(fileObject);
 
                 if (Config.KustoCompressed)
                 {
@@ -377,11 +379,10 @@ namespace CollectSFData.DataFile
             else if (Config.IsLogAnalyticsConfigured())
             {
                 // la is kusto based but only accepts non compressed json format ingest
-                collection = SerializeJson(fileObject, records);
+                collection = SerializeJson<T>(fileObject);
             }
 
             collection.ForEach(x => SaveToCache(x));
-            records.Clear();
             return collection;
         }
 
@@ -400,7 +401,7 @@ namespace CollectSFData.DataFile
             }
         }
 
-        private FileObjectCollection SerializeCsv<T>(FileObject fileObject, IList<T> records)
+        private FileObjectCollection SerializeCsv<T>(FileObject fileObject)
         {
             Log.Debug("enter");
             FileObjectCollection collection = new FileObjectCollection() { fileObject };
@@ -410,14 +411,13 @@ namespace CollectSFData.DataFile
             fileObject.FileUri = $"{sourceFile}{CsvExtension}";
             List<byte> csvSerializedBytes = new List<byte>();
 
-            foreach (T record in records)
+            foreach (T record in fileObject.Stream.Read<T>())
             {
                 byte[] recordBytes = Encoding.UTF8.GetBytes(record.ToString());
 
                 if (csvSerializedBytes.Count + recordBytes.Length > MaxCsvTransmitBytes)
                 {
                     fileObject.Stream.Set(csvSerializedBytes.ToArray());
-                    fileObject.Length = fileObject.Stream.Get().Length;
                     csvSerializedBytes.Clear();
 
                     fileObject = new FileObject($"{sourceFile}.{counter}{CsvExtension}", fileObject.BaseUri);
@@ -431,57 +431,46 @@ namespace CollectSFData.DataFile
             }
 
             fileObject.Stream.Set(csvSerializedBytes.ToArray());
-            fileObject.Length = fileObject.Stream.Get().Length;
-
             Log.Debug($"csv serialized size: {csvSerializedBytes.Count} file: {fileObject.FileUri}");
             return collection;
         }
 
-        private FileObjectCollection SerializeJson<T>(FileObject fileObject, IList<T> records)
+        private FileObjectCollection SerializeJson<T>(FileObject fileObject)
         {
             Log.Debug("enter");
-            FileObjectCollection collection = new FileObjectCollection() { fileObject };
-            int counter = 0;
-
             string sourceFile = fileObject.FileUri.ToLower().Replace(JsonExtension, "");
             fileObject.FileUri = $"{sourceFile}{JsonExtension}";
-            List<byte> jsonSerializedBytes = new List<byte>();
+            FileObjectCollection collection = new FileObjectCollection();
 
-            byte[] leftBracket = Encoding.UTF8.GetBytes("[");
-            byte[] rightBracket = Encoding.UTF8.GetBytes("]");
-            byte[] comma = Encoding.UTF8.GetBytes(",");
-
-            jsonSerializedBytes.AddRange(leftBracket);
-
-            foreach (T record in records)
+            if (fileObject.Length > MaxJsonTransmitBytes)
             {
-                byte[] recordBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(record, new JsonSerializerSettings() { }));
+                FileObject newFileObject = new FileObject($"{sourceFile}", fileObject.BaseUri);
+                int recordsCount = 0;
 
-                if (jsonSerializedBytes.Count + recordBytes.Length + rightBracket.Length > MaxJsonTransmitBytes)
+                foreach (T record in fileObject.Stream.Read<T>())
                 {
-                    jsonSerializedBytes.AddRange(rightBracket);
-                    fileObject.Stream.Set(jsonSerializedBytes.ToArray());
-                    fileObject.Length = fileObject.Stream.Get().Length;
-                    jsonSerializedBytes.Clear();
+                    recordsCount++;
 
-                    fileObject = new FileObject($"{sourceFile}.{counter}{JsonExtension}", fileObject.BaseUri);
-                    jsonSerializedBytes.AddRange(leftBracket);
-
-                    Log.Debug($"json serialized size: {jsonSerializedBytes.Count} file: {fileObject.FileUri}");
-                    collection.Add(fileObject);
+                    if (newFileObject.Length < WarningJsonTransmitBytes)
+                    {
+                        newFileObject.Stream.Write<T>(new List<T>{record}, true);
+                    }
+                    else{
+                        newFileObject.FileUri = $"{sourceFile}.{recordsCount}{JsonExtension}";
+                        collection.Add(newFileObject);
+                        newFileObject = new FileObject($"{sourceFile}", fileObject.BaseUri);
+                    }
                 }
 
-                jsonSerializedBytes.AddRange(recordBytes);
-                jsonSerializedBytes.AddRange(comma);
-                counter++;
+                newFileObject.FileUri = $"{sourceFile}.{recordsCount}{JsonExtension}";
+                collection.Add(newFileObject);
+            }
+            else
+            {
+                collection.Add(fileObject);
             }
 
-            jsonSerializedBytes.RemoveRange(jsonSerializedBytes.Count - comma.Length, comma.Length);
-            jsonSerializedBytes.AddRange(rightBracket);
-            fileObject.Stream.Set(jsonSerializedBytes.ToArray());
-            fileObject.Length = fileObject.Stream.Get().Length;
-
-            Log.Debug($"json serialized size: {jsonSerializedBytes.Count} file: {fileObject.FileUri}");
+            Log.Debug($"json serialized size: {fileObject.Length} file: {fileObject.FileUri}");
             return collection;
         }
     }

--- a/src/CollectSFDataDll/DataFile/FileObject.cs
+++ b/src/CollectSFDataDll/DataFile/FileObject.cs
@@ -39,9 +39,11 @@ namespace CollectSFData.DataFile
 
         public DateTimeOffset LastModified { get; set; }
 
-        public long Length { get; set; }
+        public long Length => (long)Stream?.Length;
 
         public string NodeName { get; private set; } = FileDataTypesEnum.unknown.ToString();
+
+        public int RecordCount { get; set; }
 
         public string RelativeUri => Regex.Replace(_fileUri ?? "", BaseUri ?? "", "", RegexOptions.IgnoreCase).TrimStart('/');
 

--- a/src/CollectSFDataDll/Kusto/KustoConnection.cs
+++ b/src/CollectSFDataDll/Kusto/KustoConnection.cs
@@ -353,7 +353,7 @@ namespace CollectSFData.Kusto
             successUris.AddRange(Endpoint.Query($"['{Endpoint.TableName}']" +
                 $"| where cursor_after({_ingestCursor})" +
                 $"| where ingestion_time() > todatetime('{_instance.StartTime.ToUniversalTime().ToString("o")}')" +
-                $"| distinct RelativeUri"));
+                $"| distinct RelativeUri").Select(x => x = Path.GetFileName(x)));
 
             _ingestCursor = Endpoint.Cursor;
 
@@ -366,46 +366,46 @@ namespace CollectSFData.Kusto
 
             foreach (KustoRestRecord record in failedRecords)
             {
-                string uri = record["IngestionSourcePath"].ToString();
-                Log.Debug($"checking failed ingested relativeuri: {uri}");
+                string uriFile = Path.GetFileName(record["IngestionSourcePath"].ToString());
+                Log.Debug($"checking failed ingested relativeuri: {uriFile}");
 
-                if (!_failIngestedUris.Contains(uri))
+                if (!_failIngestedUris.Contains(uriFile))
                 {
-                    Log.Error($"adding failedUri to _failIngestedUris[{_failIngestedUris.Count()}]: {uri}", record);
-                    _failIngestedUris.Add(uri);
+                    Log.Error($"adding failedUri to _failIngestedUris[{_failIngestedUris.Count()}]: {uriFile}", record);
+                    _failIngestedUris.Add(uriFile);
                     _failureCount++;
                     _failureQueryTime = DateTime.Now.ToUniversalTime().AddMinutes(-1);
                 }
             }
 
-            foreach (string uri in _failIngestedUris)
+            foreach (string uriFile in _failIngestedUris)
             {
-                if (_messageList.Any(x => Regex.IsMatch(x, Regex.Escape(new Uri(uri).AbsolutePath.TrimStart('/')), RegexOptions.IgnoreCase)))
+                if (_messageList.Any(x => Regex.IsMatch(x, uriFile, RegexOptions.IgnoreCase)))
                 {
-                    _messageList.RemoveAll(x => Regex.IsMatch(x, Regex.Escape(new Uri(uri).AbsolutePath.TrimStart('/')), RegexOptions.IgnoreCase));
-                    Log.Error($"removing failed ingested relativeuri from _messageList[{_messageList.Count()}]: {uri}");
+                    _messageList.RemoveAll(x => Regex.IsMatch(x, uriFile, RegexOptions.IgnoreCase));
+                    Log.Error($"removing failed ingested relativeuri from _messageList[{_messageList.Count()}]: {uriFile}");
                 }
             }
 
             Log.Debug($"files ingested:{successUris.Count}");
 
-            foreach (string uri in successUris)
+            foreach (string uriFile in successUris)
             {
-                Log.Debug($"checking ingested relativeuri: {uri}");
+                Log.Debug($"checking ingested relativeuri: {uriFile}");
 
-                if (!_ingestedUris.Contains(uri))
+                if (!_ingestedUris.Contains(uriFile))
                 {
-                    Log.Info($"adding relativeuri to _ingestedUris[{_ingestedUris.Count()}]: {uri}", ConsoleColor.Green);
-                    _ingestedUris.Add(uri);
+                    Log.Info($"adding relativeuri to _ingestedUris[{_ingestedUris.Count()}]: {uriFile}", ConsoleColor.Green);
+                    _ingestedUris.Add(uriFile);
                 }
             }
 
-            foreach (string uri in _ingestedUris)
+            foreach (string uriFile in _ingestedUris)
             {
-                if (_messageList.Any(x => Regex.IsMatch(x, Regex.Escape(uri), RegexOptions.IgnoreCase)))
+                if (_messageList.Any(x => Regex.IsMatch(x, uriFile, RegexOptions.IgnoreCase)))
                 {
-                    _messageList.RemoveAll(x => Regex.IsMatch(x, Regex.Escape(uri), RegexOptions.IgnoreCase));
-                    Log.Info($"removing ingested relativeuri from _messageList[{_messageList.Count()}]: {uri}", ConsoleColor.Green);
+                    _messageList.RemoveAll(x => Regex.IsMatch(x, uriFile, RegexOptions.IgnoreCase));
+                    Log.Info($"removing ingested relativeuri from _messageList[{_messageList.Count()}]: {uriFile}", ConsoleColor.Green);
                 }
             }
 

--- a/src/CollectSFDataDll/LogAnalytics/LogAnalyticsConnection.cs
+++ b/src/CollectSFDataDll/LogAnalytics/LogAnalyticsConnection.cs
@@ -229,7 +229,7 @@ namespace CollectSFData.LogAnalytics
                 return true;
             }
 
-            string cleanUri = Regex.Replace(relativeUri, $"\\.?\\d*?({ZipExtension}|{TableExtension})", "");
+            string cleanUri = Regex.Replace(relativeUri, $"\\.?\\d*?({ZipExtension})", "");
             return !_ingestedUris.Any(x => x.Contains(cleanUri));
         }
 

--- a/src/CollectSFDataDll/LogAnalytics/LogAnalyticsConnection.cs
+++ b/src/CollectSFDataDll/LogAnalytics/LogAnalyticsConnection.cs
@@ -70,7 +70,8 @@ namespace CollectSFData.LogAnalytics
 
                 if (Config.Unique)
                 {
-                    _ingestedUris.AddRange(PostQueryList($"['{Config.LogAnalyticsName}_CL']|distinct RelativeUri_s", false));
+                    _ingestedUris.AddRange(PostQueryList($"['{Config.LogAnalyticsName}_CL']|distinct RelativeUri_s", false)
+                        .Select(x => x = Path.GetFileNameWithoutExtension(x)));
                     Log.Info($"listResults:", _ingestedUris);
                 }
             }
@@ -229,7 +230,7 @@ namespace CollectSFData.LogAnalytics
                 return true;
             }
 
-            string cleanUri = Regex.Replace(relativeUri, $"\\.?\\d*?({ZipExtension})", "");
+            string cleanUri = Regex.Replace(relativeUri, $"\\.?\\d*?({ZipExtension}|{TableExtension})", "");
             return !_ingestedUris.Any(x => x.Contains(cleanUri));
         }
 

--- a/src/CollectSFDataDll/LogAnalytics/LogAnalyticsConnection.cs
+++ b/src/CollectSFDataDll/LogAnalytics/LogAnalyticsConnection.cs
@@ -70,7 +70,7 @@ namespace CollectSFData.LogAnalytics
 
                 if (Config.Unique)
                 {
-                    _ingestedUris.AddRange(PostQueryList($"['{Config.LogAnalyticsName}_CL']|distinct RelativeUri_s"));
+                    _ingestedUris.AddRange(PostQueryList($"['{Config.LogAnalyticsName}_CL']|distinct RelativeUri_s", false));
                     Log.Info($"listResults:", _ingestedUris);
                 }
             }
@@ -104,7 +104,7 @@ namespace CollectSFData.LogAnalytics
         {
             int retry = 0;
 
-            if (fileObject.Stream.Get().Length < 1 && (!fileObject.FileUri.ToLower().EndsWith(JsonExtension) | !fileObject.Exists))
+            if (fileObject.Stream.Length < 1 && (!fileObject.FileUri.ToLower().EndsWith(JsonExtension) | !fileObject.Exists))
             {
                 Log.Warning($"no json data to send: {fileObject.FileUri}");
                 return;
@@ -374,7 +374,7 @@ namespace CollectSFData.LogAnalytics
         private bool PostData(FileObject fileObject, bool connectivityCheck = false)
         {
             Log.Debug("enter");
-            string jsonBody = Config.UseMemoryStream || connectivityCheck ? new StreamReader(fileObject.Stream.Get()).ReadToEnd() : File.ReadAllText(fileObject.FileUri);
+            string jsonBody = Config.UseMemoryStream || connectivityCheck ? fileObject.Stream.ReadToEnd() : File.ReadAllText(fileObject.FileUri);
             fileObject.Stream.Close();
             byte[] jsonBytes = Encoding.UTF8.GetBytes(jsonBody);
 
@@ -419,7 +419,7 @@ namespace CollectSFData.LogAnalytics
             }
         }
 
-        private LogAnalyticsQueryResults PostQuery(string query)
+        private LogAnalyticsQueryResults PostQuery(string query, bool displayError = true)
         {
             LogAnalyticsQueryResults laResults = new LogAnalyticsQueryResults();
             string jsonBody = $"{{\"query\": \"{query}\"}}";
@@ -440,7 +440,11 @@ namespace CollectSFData.LogAnalytics
 
                 if (!_httpClient.Success)
                 {
-                    Log.Error("unsuccessful response:", _httpClient.Response);
+                    if(displayError)
+                    {
+                        Log.Error("unsuccessful response:", _httpClient.Response);
+                    }
+
                     return null;
                 }
                 else
@@ -486,9 +490,9 @@ namespace CollectSFData.LogAnalytics
             }
         }
 
-        private List<string> PostQueryList(string query)
+        private List<string> PostQueryList(string query, bool displayError = true)
         {
-            LogAnalyticsQueryResults results = PostQuery(query);
+            LogAnalyticsQueryResults results = PostQuery(query, displayError);
             List<string> listResults = new List<string>();
 
             if (results?.tables.Length > 0)


### PR DESCRIPTION
- modify repo layout structure and place source in /src  
- add .devcontainer with net5 custom install for codespaces  
- add kusto functions  
- fix table ingest only ingesting last chunk enumerated from table  
- fix unique table ingest when kustoingestmessage false using .set-or-replace  
- fix table filter now using containerfilter  
- migrate from binaryformatter deprecated in net5 to newtonsoft json serializer  
- fix unique when kustoingestmessage false and file is over max ingest size  
- update loganalytics api version  
- add tests for msal and kusto  
- update README  
- update configuration json examples  
- add building md  
- add CHANGELOG  
