### PR TITLE
fix kusto error  Ordinal: '0' appears '1' times,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 02/27/2021
 
 - adding net462 targetframework
+- fix for new kusto error when using blob as source Ingestion properties contains invalid CsvMapping ingestion mapping. Mapping: '' Invalidity reason: CsvMapping An item with the same key has already been added. Ordinal: '0' appears '1' times,
 
 ## 02/22/2021
 
 - fix fields not matching in gathertype 'setup'. FormatTraceFile incorrectly using DtrTraceRecord instead of T. tested setup and trace gathertype
-
 
 ## 02/08/2021
 

--- a/scripts/dotnet-build.ps1
+++ b/scripts/dotnet-build.ps1
@@ -111,9 +111,14 @@ function create-nuspec($targetFrameworks) {
         write-error "nuspec $nuspecFile does not exist"
         return
     }
-    $tempNuspec = $nuspecFile.Replace(".oem", "").Replace(".nuspec", ".oem.nuspec")
+    $tempNuspec = $nuspecFile.Replace(".oem", "").Replace(".nuspec", ".nuspec.oem")
+    write-host "adding temp file $tempNuspec to list" -ForegroundColor Yellow
+    [void]$global:tempFiles.add($tempNuspec)
+    
     $nuspecXml = [xml]::new()
     $nuspecXml.Load($nuspecFile)
+    $nuspecXml.Save($tempNuspec)
+
     $nuspecXml.package.files.RemoveAll()
     $filesElement = $nuspecxml.package.GetElementsByTagName("files")
 
@@ -153,15 +158,14 @@ function create-nuspec($targetFrameworks) {
         }
     }
 
-    $nuspecXml.Save($tempNuspec)
-    [void]$global:tempFiles.add($tempNuspec)
+    $nuspecXml.Save($nuspecFile)
     return $tempNuspec
 }
 
 function create-tempProject($projectFile) {
     $projContent = Get-Content -raw $projectFile
-    $targetFrameworkString = @($targetFramework) -join ";"
-    $tempProject = $projectFile.Replace(".oem", "").Replace(".csproj", ".oem.csproj")
+    $targetFrameworkString = @($targetFrameworks) -join ";"
+    $tempProject = $projectFile.Replace(".oem", "").Replace(".csproj", ".csproj.oem")
     
     write-host "saving to $tempProject" -ForegroundColor Green
     $projContent.trim() | out-file $tempProject -Force
@@ -182,6 +186,7 @@ function create-tempProject($projectFile) {
         write-host "new frameworks: $projContent" -ForegroundColor Green
         write-host "saving to $projectFile" -ForegroundColor Green
         $projContent.trim() | out-file $projectFile -Force
+        write-host "adding temp file $tempProject to list" -ForegroundColor Yellow
         [void]$global:tempFiles.add($tempProject)
         
         return $projectFile

--- a/scripts/dotnet-build.ps1
+++ b/scripts/dotnet-build.ps1
@@ -5,7 +5,7 @@
 #>
 param(
     [ValidateSet('net472', 'netcoreapp2.2', 'netcoreapp3.1', 'net5', 'net462')]
-    [string[]]$targetFramework = @('net5'),
+    [string[]]$targetFrameworks = @('net5'),
     [ValidateSet('all', 'debug', 'release')]
     $configuration = 'all',
     [ValidateSet('win-x64', 'ubuntu.18.04-x64')]
@@ -25,6 +25,23 @@ $csproj = "$projectDir\CollectSFData\CollectSFData.csproj"
 $dllcsproj = "$projectDir\CollectSFDataDll\CollectSFDataDll.csproj"
 $frameworksPattern = "\<TargetFrameworks\>(.+?)\</TargetFrameworks\>"
 $ignoreCase = [text.regularExpressions.regexOptions]::IgnoreCase
+$nuspecFile = "$projectDir\CollectSFData\CollectSFData.nuspec"
+$xmlns = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
+
+$commonNugetFiles = @{
+    '..\bin\$configuration$\$targetFramework\*.exe'='tools\$targetFramework'
+    '..\bin\$configuration$\$targetFramework\*.dll'='tools\$targetFramework'
+    '..\bin\$configuration$\$targetFramework\CollectSFDataDll.dll'='lib\$targetFramework'
+    '..\bin\$configuration$\$targetFramework\Tx.Core.dll'='lib\$targetFramework'
+    '..\bin\$configuration$\$targetFramework\Tx.Windows.dll'='lib\$targetFramework'
+    '..\..\configurationFiles\collectsfdata.options.json'='tools\$targetFramework'
+    '..\bin\$configuration$\$targetFramework\*.config'='tools\$targetFramework'
+    '..\FabricSupport.png'='images\'
+}
+
+$netCoreNugetFiles = @{
+    '..\bin\$configuration$\$targetFramework\*.runtimeconfig.json'='tools\$targetFramework'
+}
 
 function main() {
 
@@ -35,6 +52,7 @@ function main() {
     try {
         $csproj = create-tempProject -projectFile $csproj
         $dllcsproj = create-tempProject -projectFile $dllcsproj
+        $nuspecFile = create-nuspec $targetFrameworks
         
         write-host "dotnet restore $csproj" -ForegroundColor Green
         dotnet restore $csproj
@@ -75,8 +93,8 @@ function build-configuration($configuration) {
     dotnet build $csproj -c $configuration
 
     if ($publish) {
-        write-host "dotnet publish $csproj -f $targetFramework -r $runtimeIdentifier -c $configuration --self-contained $true -p:PublishSingleFile=true -p:PublishedTrimmed=true" -ForegroundColor Magenta
-        dotnet publish $csproj -f $targetFramework -r $runtimeIdentifier -c $configuration --self-contained $true -p:PublishSingleFile=true -p:PublishedTrimmed=true
+        write-host "dotnet publish $csproj -f $targetFrameworks -r $runtimeIdentifier -c $configuration --self-contained $true -p:PublishSingleFile=true -p:PublishedTrimmed=true" -ForegroundColor Magenta
+        dotnet publish $csproj -f $targetFrameworks -r $runtimeIdentifier -c $configuration --self-contained $true -p:PublishSingleFile=true -p:PublishedTrimmed=true
     }
 
     $nugetFile = "$projectDir\bin\$configuration\*.nupkg"
@@ -87,6 +105,59 @@ function build-configuration($configuration) {
         nuget add $nugetFile -source $nugetFallbackFolder
     }
 }
+
+function create-nuspec($targetFrameworks) {
+    if (!(test-path $nuspecFile)) {
+        write-error "nuspec $nuspecFile does not exist"
+        return
+    }
+    $tempNuspec = $nuspecFile.Replace(".oem", "").Replace(".nuspec", ".oem.nuspec")
+    $nuspecXml = [xml]::new()
+    $nuspecXml.Load($nuspecFile)
+    $nuspecXml.package.files.RemoveAll()
+    $filesElement = $nuspecxml.package.GetElementsByTagName("files")
+
+    foreach ($targetFramework in $targetFrameworks) {
+        foreach ($commonNugetFile in $commonNugetFiles.GetEnumerator()) {
+            $srcPath = $commonNugetFile.Key.Replace("`$targetFramework", $targetFramework)
+            $targetPath = $commonNugetFile.Value.Replace("`$targetFramework", $targetFramework)
+
+            $element = $nuspecXml.CreateElement("file", $xmlns)
+            $src = $nuspecXml.CreateAttribute("src")
+            $src.Value = $srcPath
+            $element.Attributes.Append($src)
+
+            $target = $nuspecXml.CreateAttribute("target")
+            $target.Value = $targetPath
+            $element.Attributes.Append($target)
+
+            $filesElement.AppendChild($element)
+        }
+        
+        if ($targetFramework -imatch "netcore") {
+            foreach ($netCoreNugetFile in $netCoreNugetFiles.GetEnumerator()) {
+                $srcPath = $netCoreNugetFile.Key.Replace("`$targetFramework",$targetFramework)
+                $targetPath = $netCoreNugetFile.Value.Replace("`$targetFramework",$targetFramework)
+    
+                $element = $nuspecXml.CreateElement("file")
+                $src = $nuspecXml.CreateAttribute("src")
+                $src.Value = $srcPath
+                $element.Attributes.Append($src)
+    
+                $target = $nuspecXml.CreateAttribute("target")
+                $target.Value = $targetPath
+                $element.Attributes.Append($target)
+    
+                $filesElement.AppendChild($element)
+            }
+        }
+    }
+
+    $nuspecXml.Save($tempNuspec)
+    [void]$global:tempFiles.add($tempNuspec)
+    return $tempNuspec
+}
+
 function create-tempProject($projectFile) {
     $projContent = Get-Content -raw $projectFile
     $targetFrameworkString = @($targetFramework) -join ";"
@@ -120,3 +191,6 @@ function create-tempProject($projectFile) {
 }
 
 main
+
+
+

--- a/src/CollectSFData/CollectSFData.nuspec
+++ b/src/CollectSFData/CollectSFData.nuspec
@@ -1,126 +1,128 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <metadata>
-        <id>Microsoft.ServiceFabric.CollectSFData</id>
-        <version>$version$</version>
-        <!--<version>2.7.0</version>-->
-        <title>CollectSFData</title>
-        <authors>Microsoft</authors>
-        <owners></owners>
-        <license type="expression">MIT</license>
-        <projectUrl>https://github.com/microsoft/CollectServiceFabricData</projectUrl>
-        <iconUrl>http://raw.githubusercontent.com/microsoft/CollectServiceFabricData/master/CollectSFData/FabricSupport.ico</iconUrl>
-        <icon>images\FabricSupport.png</icon>
-        <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>.net framework / .net core console utility / dll to manage service fabric support logs.</description>
-        <releaseNotes></releaseNotes>
-        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-        <tags>servicefabric</tags>
-        <dependencies>
-            <group targetFramework=".NETFramework4.6.2">
-                <dependency id="Microsoft.Azure.KeyVault" version="3.0.4" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.KeyVault.Core" version="3.0.4" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Kusto.Data" version="8.0.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Kusto.Ingest" version="8.0.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Common" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Queue" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Identity.Client" version="4.19.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.15.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" exclude="Build,Analyzers" />
-                <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />
-                <dependency id="System.CodeDom" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="System.Data.SqlClient" version="4.8.2" exclude="Build,Analyzers" />
-                <dependency id="System.Reactive" version="4.0.0" exclude="Build,Analyzers" />
-                <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
-            </group>
-            <group targetFramework=".NETFramework4.7.2">
-                <dependency id="Microsoft.Azure.KeyVault" version="3.0.4" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.KeyVault.Core" version="3.0.4" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Kusto.Data" version="8.0.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Kusto.Ingest" version="8.0.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Common" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Queue" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Identity.Client" version="4.19.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.15.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" exclude="Build,Analyzers" />
-                <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />
-                <dependency id="System.CodeDom" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="System.Data.SqlClient" version="4.8.2" exclude="Build,Analyzers" />
-                <dependency id="System.Reactive" version="4.0.0" exclude="Build,Analyzers" />
-                <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
-            </group>
-            <group targetFramework=".NETCoreApp3.1">
-                <dependency id="Microsoft.Azure.KeyVault" version="3.0.4" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.KeyVault.Core" version="3.0.4" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Kusto.Data" version="8.0.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Kusto.Ingest" version="8.0.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Common" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Azure.Storage.Queue" version="11.1.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Identity.Client" version="4.19.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.15.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" exclude="Build,Analyzers" />
-                <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />
-                <dependency id="System.CodeDom" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="System.Data.SqlClient" version="4.8.2" exclude="Build,Analyzers" />
-                <dependency id="System.Reactive" version="4.0.0" exclude="Build,Analyzers" />
-                <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
-            </group>
-        </dependencies>
-        <frameworkAssemblies>
-            <frameworkAssembly assemblyName="System.IO" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Runtime" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Security.Claims" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.Algorithms" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.Encoding" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.Primitives" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.X509Certificates" targetFramework=".NETFramework4.6.2" />
-            <frameworkAssembly assemblyName="System.IO.Compression" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.IO" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Runtime" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Security.Claims" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.Algorithms" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.Encoding" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.Primitives" targetFramework=".NETFramework4.7.2" />
-            <frameworkAssembly assemblyName="System.Security.Cryptography.X509Certificates" targetFramework=".NETFramework4.7.2" />
-        </frameworkAssemblies>
-    </metadata>
-    <files>
-        <file src="..\bin\$configuration$\net462\*.exe" target="tools\net462" />
-        <file src="..\bin\$configuration$\net462\*.dll" target="tools\net462" />
-        <file src="..\bin\$configuration$\net462\CollectSFDataDll.dll" target="lib\net462" />
-        <file src="..\bin\$configuration$\net462\Tx.Core.dll" target="lib\net462" />
-        <file src="..\bin\$configuration$\net462\Tx.Windows.dll" target="lib\net462" />
-        <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net462" />
-        <file src="..\bin\$configuration$\net462\*.config" target="tools\net462" />
-        <file src="..\bin\$configuration$\net472\*.exe" target="tools\net472" />
-        <file src="..\bin\$configuration$\net472\*.dll" target="tools\net472" />
-        <file src="..\bin\$configuration$\net472\CollectSFDataDll.dll" target="lib\net472" />
-        <file src="..\bin\$configuration$\net472\Tx.Core.dll" target="lib\net472" />
-        <file src="..\bin\$configuration$\net472\Tx.Windows.dll" target="lib\net472" />
-        <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net472" />
-        <file src="..\bin\$configuration$\net472\*.config" target="tools\net472" />
-        <file src="..\bin\$configuration$\netcoreapp3.1\*.exe" target="tools\netcoreapp3.1" />
-        <file src="..\bin\$configuration$\netcoreapp3.1\*.runtimeconfig.json" target="tools\netcoreapp3.1" />
-        <file src="..\bin\$configuration$\netcoreapp3.1\*.dll" target="tools\netcoreapp3.1" />
-        <file src="..\bin\$configuration$\netcoreapp3.1\CollectSFDataDll.dll" target="lib\netcoreapp3.1" />
-        <file src="..\bin\$configuration$\net472\Tx.Core.dll" target="lib\netcoreapp3.1" />
-        <file src="..\bin\$configuration$\net472\Tx.Windows.dll" target="lib\netcoreapp3.1" />
-        <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\netcoreapp3.1" />
-        <file src="..\bin\$configuration$\netcoreapp3.1\*.config" target="tools\netcoreapp3.1" />
-        <file src="..\FabricSupport.png" target="images\" />
-    </files>
+  <metadata>
+    <id>Microsoft.ServiceFabric.CollectSFData</id>
+    <version>$version$</version>
+    <!--<version>2.7.0</version>-->
+    <title>CollectSFData</title>
+    <authors>Microsoft</authors>
+    <owners>
+    </owners>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/microsoft/CollectServiceFabricData</projectUrl>
+    <iconUrl>http://raw.githubusercontent.com/microsoft/CollectServiceFabricData/master/CollectSFData/FabricSupport.ico</iconUrl>
+    <icon>images\FabricSupport.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>.net framework / .net core console utility / dll to manage service fabric support logs.</description>
+    <releaseNotes>
+    </releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>servicefabric</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.2">
+        <dependency id="Microsoft.Azure.KeyVault" version="3.0.4" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="3.0.4" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Kusto.Data" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Kusto.Ingest" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Common" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Queue" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Identity.Client" version="4.19.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.15.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />
+        <dependency id="System.CodeDom" version="4.7.0" exclude="Build,Analyzers" />
+        <dependency id="System.Data.SqlClient" version="4.8.2" exclude="Build,Analyzers" />
+        <dependency id="System.Reactive" version="4.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="Microsoft.Azure.KeyVault" version="3.0.4" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="3.0.4" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Kusto.Data" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Kusto.Ingest" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Common" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Queue" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Identity.Client" version="4.19.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.15.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />
+        <dependency id="System.CodeDom" version="4.7.0" exclude="Build,Analyzers" />
+        <dependency id="System.Data.SqlClient" version="4.8.2" exclude="Build,Analyzers" />
+        <dependency id="System.Reactive" version="4.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETCoreApp3.1">
+        <dependency id="Microsoft.Azure.KeyVault" version="3.0.4" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="3.0.4" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Kusto.Data" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Kusto.Ingest" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Common" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Azure.Storage.Queue" version="11.1.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.CommandLineUtils" version="1.1.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Identity.Client" version="4.19.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Identity.Client.Extensions.Msal" version="2.15.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.20" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />
+        <dependency id="System.CodeDom" version="4.7.0" exclude="Build,Analyzers" />
+        <dependency id="System.Data.SqlClient" version="4.8.2" exclude="Build,Analyzers" />
+        <dependency id="System.Reactive" version="4.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.ProtectedData" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.IO" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Runtime" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Security.Claims" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.Algorithms" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.Encoding" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.Primitives" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.X509Certificates" targetFramework=".NETFramework4.6.2" />
+      <frameworkAssembly assemblyName="System.IO.Compression" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.IO" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Runtime" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Security.Claims" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.Algorithms" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.Encoding" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.Primitives" targetFramework=".NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Security.Cryptography.X509Certificates" targetFramework=".NETFramework4.7.2" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="..\bin\$configuration$\net462\*.exe" target="tools\net462" />
+    <file src="..\bin\$configuration$\net462\*.dll" target="tools\net462" />
+    <file src="..\bin\$configuration$\net462\CollectSFDataDll.dll" target="lib\net462" />
+    <file src="..\bin\$configuration$\net462\Tx.Core.dll" target="lib\net462" />
+    <file src="..\bin\$configuration$\net462\Tx.Windows.dll" target="lib\net462" />
+    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net462" />
+    <file src="..\bin\$configuration$\net462\*.config" target="tools\net462" />
+    <file src="..\bin\$configuration$\net472\*.exe" target="tools\net472" />
+    <file src="..\bin\$configuration$\net472\*.dll" target="tools\net472" />
+    <file src="..\bin\$configuration$\net472\CollectSFDataDll.dll" target="lib\net472" />
+    <file src="..\bin\$configuration$\net472\Tx.Core.dll" target="lib\net472" />
+    <file src="..\bin\$configuration$\net472\Tx.Windows.dll" target="lib\net472" />
+    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net472" />
+    <file src="..\bin\$configuration$\net472\*.config" target="tools\net472" />
+    <file src="..\bin\$configuration$\netcoreapp3.1\*.exe" target="tools\netcoreapp3.1" />
+    <file src="..\bin\$configuration$\netcoreapp3.1\*.runtimeconfig.json" target="tools\netcoreapp3.1" />
+    <file src="..\bin\$configuration$\netcoreapp3.1\*.dll" target="tools\netcoreapp3.1" />
+    <file src="..\bin\$configuration$\netcoreapp3.1\CollectSFDataDll.dll" target="lib\netcoreapp3.1" />
+    <file src="..\bin\$configuration$\net472\Tx.Core.dll" target="lib\netcoreapp3.1" />
+    <file src="..\bin\$configuration$\net472\Tx.Windows.dll" target="lib\netcoreapp3.1" />
+    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\netcoreapp3.1" />
+    <file src="..\bin\$configuration$\netcoreapp3.1\*.config" target="tools\netcoreapp3.1" />
+    <file src="..\FabricSupport.png" target="images\" />
+  </files>
 </package>

--- a/src/CollectSFDataDll/Kusto/KustoIngestionMappings.cs
+++ b/src/CollectSFDataDll/Kusto/KustoIngestionMappings.cs
@@ -13,7 +13,7 @@ namespace CollectSFData.Kusto
         public string ConstValue;
         public string DataType;
         public string Name;
-        public int Ordinal;
+        public int? Ordinal = null;
     }
 
     public class KustoIngestionMappings


### PR DESCRIPTION
adding net462 targetframework
fix for new kusto error when using blob as source Ingestion properties contains invalid CsvMapping ingestion mapping. Mapping: '' Invalidity reason: CsvMapping An item with the same key has already been added. Ordinal: '0' appears '1' times,