### PR TITLE
fix for blob upload exception to kusto             CloudStorageAccount.UseV1MD5 = false;

### DIFF
--- a/src/CollectSFDataDll/Kusto/KustoConnection.cs
+++ b/src/CollectSFDataDll/Kusto/KustoConnection.cs
@@ -627,7 +627,8 @@ namespace CollectSFData.Kusto
                 RetryPolicy = new IngestRetryPolicy(),
                 ParallelOperationThreadCount = _config.Threads,
             };
-
+            
+            CloudStorageAccount.UseV1MD5 = false;
             CloudBlobContainer blobContainer = new CloudBlobContainer(blobUri);
             CloudBlockBlob blockBlob = blobContainer.GetBlockBlobReference(blobName);
 


### PR DESCRIPTION
fix for blob upload exception to kusto             CloudStorageAccount.UseV1MD5 = false;