### PR TITLE
fix for 195 guid changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Change log
 
+## 11/16/2021  
+
+- fixes for breaking changes in authentication disallowing use of wellknown 195 guid. utility now requires an azure app registration 'clientid' to be specified for azure / kusto authentication. app registration needs to be added as a principal to kusto database. 
+- fix for slow utility start on .net core when not using managed identity
+- move TableMetaData record insertion to start of ingest from end of ingest for better tracking and consistency  
+- add / modify kusto query functions  
+
 ## 08/22/2021  
 
-- modify kusto certificate authentication option to use certificate instead of bearer token
-  - add ApplicationCertificateSendX5c = true
+- modify kusto certificate authentication option to use certificate instead of bearer token  
+- add ApplicationCertificateSendX5c = true
 - fix for stale .bin3 token cache requiring ui 'invalid_grant'
 - add kusto queries from sedwards
 - add privacy link as part of current ms oss guidelines

--- a/kusto/functions/sflogs/TraceReplicaPrimaries.csl
+++ b/kusto/functions/sflogs/TraceReplicaPrimaries.csl
@@ -12,7 +12,7 @@
         //| where Type contains 'RE.PrimaryCtor' or Type contains 'RE.PrimaryAckProcess' or Type contains 'RE.PrimaryClose'
         //| where Type contains 'RE.PrimaryAckProcess'
         | where Type contains 'RE.PrimaryConfiguration'
-        | where Type matches regex strcat('(?i:@',serviceGuid,')')
+        | where Type matches regex strcat('((?i)@',serviceGuid,')')
         | extend instance = extract(@';(.+?):',1,Text)
         | summarize MinTimestamp=arg_min(Timestamp,*), MaxTimestamp=arg_max(Timestamp,*) by Type,NodeName,instance
         | project Type, MinTimestamp, MaxTimestamp, NodeName, instance

--- a/kusto/functions/sflogs/base/TraceTypeDistinct.csl
+++ b/kusto/functions/sflogs/base/TraceTypeDistinct.csl
@@ -1,7 +1,7 @@
 .create-or-alter function with (docstring = "[T:string] [typeMatch:string] where T=table name and optional typeMatch string /regex filter. function to enumerate distinct Type information.", folder = "sflogs/base")
     TraceTypeDistinct(T:string, typeMatch:string=".") {
     TraceTypeNameAndIdView(T, typeMatch) 
-    //| where TypeName matches regex strcat('(?i:',typeMatch,')')
+    //| where TypeName matches regex strcat('((?i)',typeMatch,')')
     | summarize count(TypeName), arg_min(Timestamp, *), arg_max(Timestamp, *) by TypeName, Level
     | project TypeName, Level, count_TypeName, First=Timestamp, Last=Timestamp1
     | order by count_TypeName desc

--- a/kusto/functions/sflogs/base/TraceTypeDistinctTabular.csl
+++ b/kusto/functions/sflogs/base/TraceTypeDistinctTabular.csl
@@ -1,7 +1,7 @@
 .create-or-alter function with (docstring = "[T:table] [typeMatch:string] where T=sflog table name and optional typeMatch string /regex filter. function to enumerate distinct Type information.", folder = "sflogs/base")
     TraceTypeDistinctTabular(T:(Timestamp:datetime,Level:string,TID:int,PID:int,Type:string,Text:string,NodeName:string,FileType:string,RelativeUri:string), typeMatch:string=".") {
         TraceTypeNameAndIdViewTabular(T, typeMatch) 
-        //| where TypeName matches regex strcat('(?i:',typeMatch,')')
+        //| where TypeName matches regex strcat('((?i)',typeMatch,')')
         | summarize count(TypeName), arg_min(Timestamp, *), arg_max(Timestamp, *) by TypeName, Level
         | project TypeName, Level, count_TypeName, First=Timestamp, Last=Timestamp1
         | order by count_TypeName desc

--- a/kusto/functions/sflogs/base/TraceTypeNameAndIdView.csl
+++ b/kusto/functions/sflogs/base/TraceTypeNameAndIdView.csl
@@ -1,7 +1,7 @@
 .create-or-alter function with (docstring = "[T:string] [typeMatch:string] function to split Type column into TypeName and TypeId", folder = "sflogs/base")
     TraceTypeNameAndIdView(T:string, typeMatch:string=".") {
         table(T)
-        | where Type matches regex strcat('(?i:',typeMatch,')')
+        | where Type matches regex strcat('((?i)',typeMatch,')')
         //| where Type contains typeMatch
         | extend TypeId = extract(".+?@(.+)", 1, Type)
         | extend TypeName = iif(Type contains "@", extract("(.+?)@", 1, Type), Type)

--- a/kusto/functions/sflogs/base/TraceTypeNameAndIdViewTabular.csl
+++ b/kusto/functions/sflogs/base/TraceTypeNameAndIdViewTabular.csl
@@ -1,7 +1,7 @@
 .create-or-alter function with (docstring = "[T:table] [typeMatch:string] function to split Type column into TypeName and TypeId", folder = "sflogs/base")
     TraceTypeNameAndIdViewTabular(T:(Timestamp:datetime,Level:string,TID:int,PID:int,Type:string,Text:string,NodeName:string,FileType:string,RelativeUri:string), typeMatch:string=".") {
         T
-        | where Type matches regex strcat('(?i:',typeMatch,')')
+        | where Type matches regex strcat('((?i)',typeMatch,')')
         | extend TypeId = extract(".+?@(.+)", 1, Type)
         | extend TypeName = iif(Type contains "@", extract("(.+?)@", 1, Type), Type)
         | order by Timestamp asc

--- a/kusto/functions/sflogs/cluster-manager/TraceCMReplicaPrimaries.csl
+++ b/kusto/functions/sflogs/cluster-manager/TraceCMReplicaPrimaries.csl
@@ -12,7 +12,7 @@
         //| where Type contains 'RE.PrimaryCtor' or Type contains 'RE.PrimaryAckProcess' or Type contains 'RE.PrimaryClose'
         //| where Type contains 'RE.PrimaryAckProcess'
         | where Type contains 'RE.PrimaryConfiguration'
-        | where Type matches regex strcat('(?i:@',serviceGuid,')')
+        | where Type matches regex strcat('((?i)@',serviceGuid,')')
         | extend instance = extract(@';(.+?):',1,Text)
         | summarize MinTimestamp=arg_min(Timestamp,*), MaxTimestamp=arg_max(Timestamp,*) by Type,NodeName,instance
         | project Type, MinTimestamp, MaxTimestamp, NodeName, instance

--- a/kusto/functions/sflogs/errors/TraceFalsePositiveTabular.csl
+++ b/kusto/functions/sflogs/errors/TraceFalsePositiveTabular.csl
@@ -18,8 +18,8 @@
         };
         // search Type And Text column using regex insensitive match
         let TypeAndTextIMatches = (tableName:(Type:string,Text:string,FalsePositive:bool,Reason:string),issue:string, typeQuery:string, textQuery:string) {
-            let itypeQuery = strcat('(?i:',typeQuery,')'); // re2 case insensitive
-            let itextQuery = strcat('(?i:',textQuery,')'); // re2 case insensitive
+            let itypeQuery = strcat('((?i)',typeQuery,')'); // re2 case insensitive
+            let itextQuery = strcat('((?i)',textQuery,')'); // re2 case insensitive
             tableName
             | extend isFalsePositive = iif((Type matches regex itypeQuery and Text matches regex itextQuery),true,false)
             | extend Reason = iif(isFalsePositive, strcat(issue,' ::type matches: ', typeQuery, ' ::text matches: ', textQuery ), Reason)
@@ -44,7 +44,7 @@
         };
         // search Text column using regex insensitive match
         let TextIMatches = (tableName:(Type:string,Text:string,FalsePositive:bool,Reason:string), issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             tableName
             | extend isFalsePositive = iif((Text matches regex iQuery),true,false)
             | extend Reason = iif(isFalsePositive, strcat(issue,' ::text matches: ', query ), Reason)
@@ -69,7 +69,7 @@
         };
         // search Type column using regex insensitive match
         let TypeIMatches = (tableName:(Type:string,Text:string,FalsePositive:bool,Reason:string), issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             tableName
             | extend isFalsePositive = iif((Type matches regex iQuery),true,false)
             | extend Reason = iif(isFalsePositive, strcat(issue,' ::type matches: ', query ), Reason)
@@ -94,7 +94,7 @@
         };
         // search Type or Text columns using regex insensitive match
         let TypeOrTextIMatches = (tableName:(Type:string,Text:string,FalsePositive:bool,Reason:string), issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             tableName
             | extend isFalsePositive = iif((Type matches regex iQuery or Text matches regex iQuery),true,false)
             | extend Reason = iif(isFalsePositive, strcat(issue,' ::type or text matches: ', query ), Reason)

--- a/kusto/functions/sflogs/errors/TraceKnownIssue.csl
+++ b/kusto/functions/sflogs/errors/TraceKnownIssue.csl
@@ -22,7 +22,7 @@
         };
         // search any column using regex insensitive match
         let AnyIMatches = (tableName:string, issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             table(tableName) 
             | extend KnownIssue = iif((* matches regex iQuery), true, false) 
             | extend Reason = iif(KnownIssue, strcat(issue,' ::any imatches: ', iQuery), "")
@@ -55,8 +55,8 @@
         };
         // search Type And Text column using regex insensitive match
         let TypeAndTextIMatches = (tableName:string, issue:string, typeQuery:string, textQuery:string) {
-            let itypeQuery = strcat('(?i:',typeQuery,')'); // re2 case insensitive
-            let itextQuery = strcat('(?i:',textQuery,')'); // re2 case insensitive
+            let itypeQuery = strcat('((?i)',typeQuery,')'); // re2 case insensitive
+            let itextQuery = strcat('((?i)',textQuery,')'); // re2 case insensitive
             table(tableName) 
             | extend KnownIssue = iif((Type matches regex itypeQuery and Text matches regex itextQuery), true, false) 
             | extend Reason = iif(KnownIssue, strcat(issue,' ::type matches: ', typeQuery, ' ::text matches: ', textQuery ), "")
@@ -88,7 +88,7 @@
         };
         // search Text column using regex insensitive match
         let TextIMatches = (tableName:string, issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             table(tableName) 
             | extend KnownIssue = iif((Text matches regex iQuery), true, false) 
             | extend Reason = iif(KnownIssue, strcat(issue,' ::text imatches: ', iQuery), "")
@@ -119,7 +119,7 @@
         };
         // search Type column using regex insensitive match
         let TypeIMatches = (tableName:string, issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             table(tableName) 
             | extend KnownIssue = iif((Type matches regex iQuery), true, false) 
             | extend Reason = iif(KnownIssue, strcat(issue,' ::type imatches: ', iQuery), "")
@@ -152,7 +152,7 @@
         };
         // search Type or Text columns using regex insensitive match
         let TypeOrTextIMatches = (tableName:string, issue:string, query:string) {
-            let iQuery = strcat('(?i:',query,')'); // re2 case insensitive
+            let iQuery = strcat('((?i)',query,')'); // re2 case insensitive
             table(tableName) 
             | extend KnownIssue = iif((Type matches regex iQuery or Text matches regex iQuery), true, false) 
             | extend Reason = iif(KnownIssue, strcat(issue,' ::type or text imatches: ', iQuery ), "")

--- a/kusto/functions/sflogs/errors/TraceTextExceptionsDistinct.csl
+++ b/kusto/functions/sflogs/errors/TraceTextExceptionsDistinct.csl
@@ -3,7 +3,7 @@
         let baseUri = CreateKustoWebQueryLink('');
         table(T)
         | where Text contains "exception"
-        | extend text_exception = tostring(extract_all(@"(?i:(?P<text_exceptions>(\s|\S+)exception(\s|\S+)))", dynamic(['text_exceptions']), Text))
+        | extend text_exception = tostring(extract_all(@"((?i)(?P<text_exceptions>(\s|\S+)exception(\s|\S+)))", dynamic(['text_exceptions']), Text))
         | summarize count(text_exception), First = arg_min(Timestamp, *), Last = arg_max(Timestamp, *) by text_exception, NodeName
         | order by text_exception asc
         | extend exception_pattern = replace("'","",replace(",",@".*",trim('\"|\\[|\\]',text_exception)))

--- a/kusto/functions/sflogs/failover-manager/TraceFMInProgress_AppUpgradeGraph.csl
+++ b/kusto/functions/sflogs/failover-manager/TraceFMInProgress_AppUpgradeGraph.csl
@@ -16,7 +16,7 @@
             @', Cancel=' ['cancel']
             @', NotReady=' notReady
             @', PLBSafetyCheckStatus=' plbSafetyCheckStatus
-        | where app matches regex strcat('(?i:',appName,')')
+        | where app matches regex strcat('((?i)',appName,')')
         | summarize 
             max(toint(domain)), 
             max(toint(tobool(isContextCompleted))),

--- a/kusto/functions/sflogs/patch-orchestration/TracePOARepairTasks.csl
+++ b/kusto/functions/sflogs/patch-orchestration/TracePOARepairTasks.csl
@@ -10,7 +10,7 @@
             @', Description = ' taskDescription
             @', ExecutorData = ' executorData
             @', Target = ' target
-        | where taskId matches regex strcat('(?i:',taskName,')')
+        | where taskId matches regex strcat('((?i)',taskName,')')
         | extend json = parse_json(replace("''",'"',executorData))
         | extend executorSubState = toint(json.ExecutorSubState)
         | extend subState = case(executorSubState == -12, "DllNotFoundException",

--- a/kusto/functions/sftable/TableViewTask.csl
+++ b/kusto/functions/sftable/TableViewTask.csl
@@ -1,6 +1,6 @@
 .create-or-alter function with (docstring = "function to create TableView Task view by TaskName for sftable", folder = "sftable")
     TableViewTask(T:string, taskName:string=".", startTimeStamp:datetime=datetime(null), endTimeStamp:datetime=datetime(null)) {
-        let iTaskName = strcat('(?i:^',taskName,'$)'); // re2 case insensitive
+        let iTaskName = strcat('((?i)^',taskName,'$)'); // re2 case insensitive
         TableView(T,startTimeStamp,endTimeStamp)
         | where TaskName matches regex iTaskName
         | order by Timestamp asc

--- a/kusto/log-analytics/log-analytics-example-queries.csl
+++ b/kusto/log-analytics/log-analytics-example-queries.csl
@@ -63,7 +63,7 @@ let filterPattern = @'Dns.+Duration \((?P<ms> \d{2,5}) ms \)';
 
 // regex example with match case insensitive
 let filterPattern = @'lease';
-let regexPattern = strcat('(?i:',filterPattern,')'); // re2 case insensitive
+let regexPattern = strcat('((?i)',filterPattern,')'); // re2 case insensitive
 '%log analytics custom log name%'
 | where Type_s matches regex regexPattern or Text matches regex regexPattern
 //| where Type_s contains filterPattern or Text contains filterPattern

--- a/kusto/queries/examples_traces.csl
+++ b/kusto/queries/examples_traces.csl
@@ -13,7 +13,7 @@ your_tablename_here
     or Type contains strcat(@'ApplicationUpgradeDomainComplete@', appName)
     or Text contains @'Phase='
     or Text contains @'failed'
-    or ((Type contains strcat(@'HM.Entity_QueryCompleted@', appName)) and (Text matches regex strcat('(?i:',@'is in Error',')') or Text matches regex strcat('(?i:',@'is in Warning',')')))
+    or ((Type contains strcat(@'HM.Entity_QueryCompleted@', appName)) and (Text matches regex strcat('((?i)',@'is in Error',')') or Text matches regex strcat('((?i)',@'is in Warning',')')))
 | where Type !contains exclusion1 and Text !contains exclusion1
 | project Timestamp , TID , PID , NodeName , Level , Type , Text , FileType
 | order by Timestamp asc
@@ -29,7 +29,7 @@ let extractPattern_ServiceName = @'(fabric):\/([\w_-]+)\/([\w_-]+)';
 your_tablename_here
 | where Type contains @'HM.Entity_QueryCompleted'
 | where Type matches regex filterPattern
-  and (Text matches regex strcat('(?i:',@'is in Error',')') or Text matches regex strcat('(?i:',@'is in Warning',')'))
+  and (Text matches regex strcat('((?i)',@'is in Error',')') or Text matches regex strcat('((?i)',@'is in Warning',')'))
 | extend partitionStats = extract(extractPattern_PartitionStats, 0, Text, typeof(string))
 | extend replicaStats = extract(extractPattern_ReplicaStats, 0, Text, typeof(string))
 | extend serviceName = extract(extractPattern_ServiceName, 0, Text, typeof(string))
@@ -64,9 +64,9 @@ your_tablename_here
 let appName = @'fabric:/';
 your_tablename_here
 | where Type contains @'FM.AppUpgrade'
-| where Text matches regex strcat('(?i:',@'accepted',')')  
-    or Text matches regex strcat('(?i:',@'and moving to',')')  
-    or Text matches regex strcat('(?i:',@'Starting',')')   
+| where Text matches regex strcat('((?i)',@'accepted',')')  
+    or Text matches regex strcat('((?i)',@'and moving to',')')  
+    or Text matches regex strcat('((?i)',@'Starting',')')   
 | project Timestamp , TID , PID , NodeName , Level , Type , Text , FileType
 | order by Timestamp asc
 | limit 5000
@@ -83,7 +83,7 @@ your_tablename_here
     or Type contains strcat(@'ApplicationUpgradeDomainComplete@', appName)
     or Text contains @'Phase='
     or Text contains @'failed'
-    or ((Type contains strcat(@'HM.Entity_QueryCompleted@', appName)) and (Text matches regex strcat('(?i:',@'is in Error',')') or Text matches regex strcat('(?i:',@'is in Warning',')')))
+    or ((Type contains strcat(@'HM.Entity_QueryCompleted@', appName)) and (Text matches regex strcat('((?i)',@'is in Error',')') or Text matches regex strcat('((?i)',@'is in Warning',')')))
 | where Type !contains exclusion1 and Text !contains exclusion1
 | project Timestamp , TID , PID , NodeName , Level , Type , Text , FileType
 | order by Timestamp asc
@@ -91,7 +91,7 @@ your_tablename_here
 
 // regex example with string match 'exception', case insensitive
 let filterPattern1 = @'exception';
-let regexPattern1 = strcat('(?i:',filterPattern1,')'); // re2 case insensitive
+let regexPattern1 = strcat('((?i)',filterPattern1,')'); // re2 case insensitive
 your_tablename_here
 | where Type matches regex regexPattern1 or Text matches regex regexPattern1 
 | where Level !contains "Informational"

--- a/kusto/queries/kusto-example-queries.csl
+++ b/kusto/queries/kusto-example-queries.csl
@@ -77,7 +77,7 @@ let filterPattern = @'Dns.+Duration \((?P<ms> \d{2,5}) ms \)';
 
 // regex example with match case insensitive
 let filterPattern = @'lease';
-let regexPattern = strcat('(?i:',filterPattern,')'); // re2 case insensitive
+let regexPattern = strcat('((?i)',filterPattern,')'); // re2 case insensitive
 '%kusto table name%'
 | where Type matches regex regexPattern or Text matches regex regexPattern
 //| where Type contains filterPattern or Text contains filterPattern

--- a/kusto/queries/sflogs-query-regex.csl
+++ b/kusto/queries/sflogs-query-regex.csl
@@ -11,11 +11,11 @@ declare query_parameters (T:string,
         StartTimeUtc:datetime = datetime("0001-01-01T00:00:00"), 
         EndTimeUtc:datetime = datetime("9999-12-31T23:59:59"), 
         Limit:long = 10000);
-let itype = strcat('(?i:', type,')'); 
-let itext = strcat('(?i:', text,')'); 
-let ilevel = strcat('(?i:', level,')'); 
-let ifileType = strcat('(?i:', fileType,')'); 
-let inodeName = strcat('(?i:', nodeName,')'); 
+let itype = strcat('((?i)', type,')'); 
+let itext = strcat('((?i)', text,')'); 
+let ilevel = strcat('((?i)', level,')'); 
+let ifileType = strcat('((?i)', fileType,')'); 
+let inodeName = strcat('((?i)', nodeName,')'); 
 table(T)
 | where Timestamp between (StartTimeUtc .. EndTimeUtc)
 | where Type matches regex itype 

--- a/src/CollectSFDataDll/Azure/AzureResourceManager.cs
+++ b/src/CollectSFDataDll/Azure/AzureResourceManager.cs
@@ -33,7 +33,6 @@ namespace CollectSFData.Azure
         private string _resource;
         private Timer _timer;
         private DateTimeOffset _tokenExpirationHalfLife;
-        private string _wellKnownClientId = "1950a258-227b-4e31-a9cf-717495945fc2";
 
         public delegate void MsalDeviceCodeHandler(DeviceCodeResult arg);
 
@@ -207,11 +206,14 @@ namespace CollectSFData.Azure
 
                 return true;
             }
-            else
+            else if (_config.IsGuid(_config.AzureClientId))
             {
-                CreatePublicClient(prompt, _config.IsGuid(_config.AzureClientId) ? _config.AzureClientId : _wellKnownClientId, deviceLogin);
+                CreatePublicClient(prompt, _config.AzureClientId, deviceLogin);
                 return true;
             }
+
+            Log.Error("unknown configuration");
+            return false;
         }
 
         public void CreateConfidentialCertificateClient(string resource, X509Certificate2 clientCertificate)

--- a/src/CollectSFDataDll/Azure/AzureResourceManager.cs
+++ b/src/CollectSFDataDll/Azure/AzureResourceManager.cs
@@ -77,7 +77,11 @@ namespace CollectSFData.Azure
                     _config.AzureTenantId = _commonTenantId;
                 }
 
-                CreateClient(false, false, resource);
+                if(!CreateClient(false, false, resource))
+                {
+                    throw new MsalClientException("silent authentication failed");
+                }
+                
                 return SetToken();
             }
             catch (MsalClientException e)

--- a/src/CollectSFDataDll/Azure/ClientIdentity.cs
+++ b/src/CollectSFDataDll/Azure/ClientIdentity.cs
@@ -63,8 +63,18 @@ namespace CollectSFData.Azure
 
             try
             {
-                using (TcpClient client = new TcpClient(hostUri, portNumber))
+                using (TcpClient client = new TcpClient())
                 {
+                    IAsyncResult asyncResult = client.BeginConnect(hostUri, portNumber, null, null);
+                    using(asyncResult.AsyncWaitHandle)
+                    {
+                        if(!asyncResult.AsyncWaitHandle.WaitOne(Constants.ThreadSleepMs100, false))
+                        {
+                            Log.Debug($"timed out ({Constants.ThreadSleepMs100}ms) pinging host:{hostUri}:{portNumber}");
+                            return false;
+                        }
+                    }
+
                     Log.Info($"successful pinging host:{hostUri}:{portNumber}", ConsoleColor.Green);
                     return true;
                 }

--- a/src/CollectSFDataDll/Common/ConfigurationOptions.cs
+++ b/src/CollectSFDataDll/Common/ConfigurationOptions.cs
@@ -357,7 +357,6 @@ namespace CollectSFData.Common
                 || (HasValue(AzureClientId) & !HasValue(AzureKeyVault) & !HasValue(AzureClientCertificate) & HasValue(AzureClientSecret)) // app registration with clientsecret
                 || (HasValue(AzureClientId) & HasValue(AzureKeyVault) & !HasValue(AzureClientCertificate) & HasValue(AzureClientSecret)) // app registration with kv user managed
                 || (!HasValue(AzureClientId) & HasValue(AzureKeyVault) & !HasValue(AzureClientCertificate) & HasValue(AzureClientSecret)) // system managed identity with kv
-                || (HasValue(AzureClientId) & !HasValue(AzureKeyVault) & !HasValue(AzureClientCertificate) & !HasValue(AzureClientSecret)) // user managed identity
             );
 
             Log.Debug($"exit:configured:{configured} azureClientId:{AzureClientId} clientCertificate:{ClientCertificate} azureKeyVault:{AzureKeyVault} azureClientSecret:{AzureClientSecret}");

--- a/src/CollectSFDataDll/Kusto/KustoEndpoint.cs
+++ b/src/CollectSFDataDll/Kusto/KustoEndpoint.cs
@@ -100,11 +100,6 @@ namespace CollectSFData.Kusto
         {
             _arm.Scopes = new List<string>() { $"{ClusterIngestUrl}/user_impersonation" };
 
-            if (_config.IsClientIdConfigured())
-            {
-                _arm.Scopes = new List<string>() { $"{ClusterIngestUrl}/.default" };
-            }
-
             if (_config.IsKustoConfigured() && _arm.Authenticate(throwOnError, ClusterIngestUrl))
             {
                 if (_arm.ClientIdentity.IsAppRegistration)


### PR DESCRIPTION

- fixes for breaking changes in authentication disallowing use of wellknown 195 guid. utility now requires an azure app registration 'clientid' to be specified for azure / kusto authentication. app registration needs to be added as a principal to kusto database. 
- fix for slow utility start on .net core when not using managed identity
- move TableMetaData record insertion to start of ingest from end of ingest for better tracking and consistency  
- add / modify kusto query functions  