### PR TITLE
add check to not requeue processed files in predefined cache location if already in fileobjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 12/6/2022
+
+- add check to not requeue processed files in predefined cache location if already in fileobjects object for UploadCacheData().
+
 ## 10/23/2022
 
 - modify example / test sasuris falsely being flagged as secrets.

--- a/src/CollectSFDataDll/Common/ConfigurationOptions.cs
+++ b/src/CollectSFDataDll/Common/ConfigurationOptions.cs
@@ -421,6 +421,11 @@ namespace CollectSFData.Common
             return HasValue(LogAnalyticsPurge);
         }
 
+        public bool IsUploadConfigured()
+        {
+            return IsKustoConfigured() | IsLogAnalyticsConfigured();
+        }
+
         public void MergeConfig(string optionsFile)
         {
             JObject fileOptions = ReadConfigFile(optionsFile);
@@ -787,7 +792,7 @@ namespace CollectSFData.Common
                 }
             }
 
-            if (IsKustoConfigured() & IsLogAnalyticsConfigured())
+            if (IsUploadConfigured())
             {
                 Log.Error($"kusto and log analytics *cannot* both be enabled. remove configuration for one");
                 retval = false;


### PR DESCRIPTION
add check to not requeue processed files in predefined cache location if already in fileobjects