### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -104,9 +104,9 @@ jobs:
         run: |
           $nugetPackage = (get-item "$($env:release_path)\*.nupkg").FullName
           $nugetPackageName = (get-item "$($env:release_path)\*.nupkg").Name
-          echo "nuget_package=$nugetPackage" >> $GITHUB_OUTPUT
-          echo "nuget_package_name=$nugetPackageName" >> $GITHUB_OUTPUT
-        
+          echo "nuget_package=$nugetPackage" >> $env:GITHUB_OUTPUT
+          echo "nuget_package_name=$nugetPackageName" >> $env:GITHUB_OUTPUT
+
       - name: prepare release asset
         shell: powershell
         id: prepare_release_asset
@@ -120,7 +120,7 @@ jobs:
           compress-archive -path "$($env:release_path)_upload\*" -destinationPath "$($env:release_path)\$($env:project_name).zip" -force
           $fileVersion = [io.fileinfo]::new("$($releaseFramework)\$($env:project_name).exe").VersionInfo.FileVersion
           echo "::log-command parameter1=$fileVersion::fileVersion"
-          echo "file_version=v$fileVersion" >> $GITHUB_OUTPUT
+          echo "file_version=v$fileVersion" >> $env:GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -104,8 +104,8 @@ jobs:
         run: |
           $nugetPackage = (get-item "$($env:release_path)\*.nupkg").FullName
           $nugetPackageName = (get-item "$($env:release_path)\*.nupkg").Name
-          echo "::set-output name=nuget_package::$nugetPackage"
-          echo "::set-output name=nuget_package_name::$nugetPackageName"
+          echo "nuget_package=$nugetPackage" >> $GITHUB_OUTPUT
+          echo "nuget_package_name=$nugetPackageName" >> $GITHUB_OUTPUT
         
       - name: prepare release asset
         shell: powershell
@@ -120,7 +120,7 @@ jobs:
           compress-archive -path "$($env:release_path)_upload\*" -destinationPath "$($env:release_path)\$($env:project_name).zip" -force
           $fileVersion = [io.fileinfo]::new("$($releaseFramework)\$($env:project_name).exe").VersionInfo.FileVersion
           echo "::log-command parameter1=$fileVersion::fileVersion"
-          echo "::set-output name=file_version::v$fileVersion"
+          echo "file_version=v$fileVersion" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


