### PR TITLE
modify git actions release workflow for updated github token permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -123,7 +123,9 @@ jobs:
           $destination = "$($env:release_path)\\$($env:project_name).zip"
           write-host "compress-archive -path $source -destinationPath $destination -force"
           compress-archive -path $source -destinationPath $destination -force
-          $fileVersion = [io.fileinfo]::new("$($releaseFramework)\$($env:project_name).exe").VersionInfo.FileVersion
+          $exeFileRef = @(get-childItem -recurse "$($env:release_path)\$($env:project_name).exe")[0].FullName
+          $fileVersion = [io.fileinfo]::new($exeFileRef).VersionInfo.FileVersion
+          write-host "fileVersion=$fileVersion"
           echo "::log-command parameter1=$fileVersion::fileVersion"
           echo "file_version=v$fileVersion" >> $env:GITHUB_OUTPUT
           write-host "dir $env:release_path -recurse"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,11 +2,10 @@ name: CI CollectSFData
 
 env:
   project_name: CollectSFData
-  project_root: .\src
-  artifacts_path: .\src\bin\artifacts
-  release_path: .\src\bin\Release
-  release_config: .\configurationFiles\collectsfdata.options.json
-  target_version: net48
+  project_root: ${{ github.workspace }}\\src
+  artifacts_path: ${{ github.workspace }}\\src\\bin\\artifacts
+  release_path: ${{ github.workspace }}\\src\\bin\\Release
+  release_config: ${{ github.workspace }}\\configurationFiles\\collectsfdata.options.json
   github_owner: ${{ github.event.repository.owner.name }}
 
 on:
@@ -19,6 +18,7 @@ on:
     branches:
       - master
       - main
+
 jobs:
   build:
     runs-on: windows-latest
@@ -62,9 +62,11 @@ jobs:
         shell: powershell
         run: |
           [environment]::GetEnvironmentVariables()
-          dir
+          write-host "copy "$($env:release_path)" "$($env:artifacts_path)" -recurse -force"
           copy "$($env:release_path)" "$($env:artifacts_path)" -recurse -force
+          write-host "copy "$($env:release_config)" "$($env:artifacts_path)" -recurse -force"
           copy "$($env:release_config)" "$($env:artifacts_path)" -recurse -force
+          dir "$($env:artifacts_path)" -recurse
 
       - name: artifacts output
         shell: powershell
@@ -80,6 +82,10 @@ jobs:
     if: success() && github.event.pull_request.merged == true && github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'Release') || contains(github.event.pull_request.labels.*.name, 'Pre-release'))
     needs: build
     runs-on: windows-latest
+    permissions:
+      contents: write
+      packages: write
+
     steps:
       - name: checkout
         uses: actions/checkout@v1
@@ -106,53 +112,36 @@ jobs:
           $nugetPackageName = (get-item "$($env:release_path)\*.nupkg").Name
           echo "nuget_package=$nugetPackage" >> $env:GITHUB_OUTPUT
           echo "nuget_package_name=$nugetPackageName" >> $env:GITHUB_OUTPUT
+          write-host "nuget_package=$nugetPackage"
+          write-host "nuget_package_name=$nugetPackageName"
 
       - name: prepare release asset
         shell: powershell
         id: prepare_release_asset
         run: |
-          md "$($env:release_path)_upload"
-          $releaseFramework = "$($env:release_path)\$($env:target_version)"
-          copy "$($releaseFramework)\*.config" "$($env:release_path)_upload"
-          copy "$($releaseFramework)\*.exe" "$($env:release_path)_upload"
-          copy "$($releaseFramework)\*.dll" "$($env:release_path)_upload"
-          copy "$($releaseFramework)\*.json" "$($env:release_path)_upload"
-          compress-archive -path "$($env:release_path)_upload\*" -destinationPath "$($env:release_path)\$($env:project_name).zip" -force
+          $source = "$($env:release_path)\\*"
+          $destination = "$($env:release_path)\\$($env:project_name).zip"
+          write-host "compress-archive -path $source -destinationPath $destination -force"
+          compress-archive -path $source -destinationPath $destination -force
           $fileVersion = [io.fileinfo]::new("$($releaseFramework)\$($env:project_name).exe").VersionInfo.FileVersion
           echo "::log-command parameter1=$fileVersion::fileVersion"
           echo "file_version=v$fileVersion" >> $env:GITHUB_OUTPUT
+          write-host "dir $env:release_path -recurse"
+          dir $env:release_path -recurse
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # https://github.com/marketplace/actions/gh-release
       - name: create release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
+          files: |
+            **/${{ env.project_name }}.zip
+            **/*${{ env.project_name }}*.nupkg
           tag_name: ${{ steps.prepare_release_asset.outputs.file_version }}
-          release_name: ${{ env.project_name }}
+          name: ${{ env.project_name }}
           draft: false
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ contains(github.event.pull_request.labels.*.name, 'Pre-release') }}
-
-      - name: upload release asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.release_path }}\${{ env.project_name }}.zip
-          asset_name: ${{ env.project_name }}.zip
-          asset_content_type: application/zip
-
-      - name: upload nuget release asset
-        id: upload-nuget-release-asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.set_nuget_package.outputs.nuget_package }}
-          asset_name: ${{ steps.set_nuget_package.outputs.nuget_package_name }}
-          asset_content_type: application/zip
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 03/16/2024
+
+- add all target frameworks to zip for release
+- update git actions workflow release. add permissions
+    permissions:
+      contents: write
+      packages: write
+
 ## 03/11/2024
 
 - update kusto quickstart doc with modified image and minimum sas permissions

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -18,6 +18,7 @@ variables:
   artifacts_share_target: 'Z:\$(System.DefinitionName)\$(System.JobId)\$(start_time)'
   system.debug: true
   buildConfiguration: debug
+  targetPath: $(System.DefaultWorkingDirectory)/src/bin/$(buildConfiguration)
 
 steps:
 - task: PowerShell@2
@@ -64,7 +65,7 @@ steps:
 
 - task: ManifestGeneratorTask@0
   inputs:
-    BuildDropPath: $(System.DefaultWorkingDirectory)/src/bin/$(buildConfiguration)
+    BuildDropPath: $(targetPath)
     Verbosity: Verbose
     PackageName: CollectSFData
 
@@ -102,7 +103,7 @@ steps:
 
 - task: PublishPipelineArtifact@1
   inputs:
-    targetPath:  $(System.DefaultWorkingDirectory)/src/bin/$(buildConfiguration)
+    targetPath:  $(targetPath)
     artifactName: build-$(start_time)-$(system.JobId)
 
 - task: PublishPipelineArtifact@1
@@ -131,10 +132,10 @@ steps:
         write-host "mkdir "$env:artifacts_share_target""
         mkdir "$env:artifacts_share_target"
       }
-      write-host "copy $(System.DefaultWorkingDirectory)/src/bin/$(buildConfiguration) "$env:artifacts_share_target" -recurse"
-      copy $(System.DefaultWorkingDirectory)/src/bin/$(buildConfiguration) "$env:artifacts_share_target" -recurse
-      write-host "copy $(System.ArtifactsDirectory) "$env:artifacts_share_target" -recurse"
-      copy $(System.ArtifactsDirectory) "$env:artifacts_share_target" -recurse
+      write-host "copy $env:targetPath $env:artifacts_share_target -recurse"
+      copy "$env:targetPath" "$env:artifacts_share_target" -recurse
+      write-host "copy $(System.ArtifactsDirectory) $env:artifacts_share_target -recurse"
+      copy "$(System.ArtifactsDirectory)"" "$env:artifacts_share_target" -recurse
     errorActionPreference: 'continue'
     verbosePreference: 'continue'
     debugPreference: 'continue'
@@ -151,3 +152,13 @@ steps:
 #     targetPath: '$(artifacts_share_target)'
 #     allowPartiallySucceededBuilds: true
 #     allowFailedBuilds: true
+
+# # https://aka.ms/esrp
+# - task: EsrpCodeSigning@4
+#   inputs:
+#     FolderPath: $(targetPath)
+#     Pattern: '*.dll,*.exe,*.zip,*.nupkg'
+#     SessionTimeout: '60'
+#     MaxConcurrency: '50'
+#     MaxRetryAttempts: '5'
+#     PendingAnalysisWaitTimeoutMinutes: '5'

--- a/src/CollectSFData/CollectSFData.nuspec
+++ b/src/CollectSFData/CollectSFData.nuspec
@@ -102,12 +102,12 @@
   </metadata>
   <files>
     <!-- net462 tools -->
-    <file src="..\bin\$configuration$\net462\*.exe" target="tools\net462" />
+    <!-- <file src="..\bin\$configuration$\net462\*.exe" target="tools\net462" />
     <file src="..\bin\$configuration$\net462\*.dll" target="tools\net462" />
     <file src="..\bin\$configuration$\net462\*.pdb" target="tools\net462" />
     <file src="..\bin\$configuration$\net462\manifests\*.man" target="tools\net462\manifests" />
     <file src="..\bin\$configuration$\net462\*.config" target="tools\net462" />
-    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net462" />
+    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net462" /> -->
     <!-- net462 lib -->
     <file src="..\bin\$configuration$\net462\CollectSFDataDll.dll" target="lib\net462" />
     <file src="..\bin\$configuration$\net462\Sf.Tx.Core.dll" target="lib\net462" />
@@ -145,13 +145,13 @@
     <file src="..\bin\$configuration$\net6.0\Etlreader.dll" target="lib\net6.0" />
     <file src="..\bin\$configuration$\net6.0\System.Fabric.Strings.dll" target="lib\net6.0" />
     <!-- net8.0 tools -->
-    <file src="..\bin\$configuration$\net8.0\*.exe" target="tools\net8.0" />
+    <!-- <file src="..\bin\$configuration$\net8.0\*.exe" target="tools\net8.0" />
     <file src="..\bin\$configuration$\net8.0\*.runtimeconfig.json" target="tools\net8.0" />
     <file src="..\bin\$configuration$\net8.0\*.dll" target="tools\net8.0" />
     <file src="..\bin\$configuration$\net8.0\*.pdb" target="tools\net8.0" />
     <file src="..\bin\$configuration$\net8.0\manifests\*.man" target="tools\net8.0\manifests" />
     <file src="..\bin\$configuration$\net8.0\*.config" target="tools\net8.0" />
-    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net8.0" />
+    <file src="..\..\configurationFiles\collectsfdata.options.json" target="tools\net8.0" /> -->
     <!-- net8.0 lib -->
     <file src="..\bin\$configuration$\net8.0\CollectSFDataDll.dll" target="lib\net8.0" />
     <file src="..\bin\$configuration$\net8.0\Sf.Tx.Core.dll" target="lib\net8.0" />


### PR DESCRIPTION
modify git actions release workflow for updated github token permissions
update deprecated actions/create-release -> softprops/action-gh-release@v2
reconfigure .zip to include net462,net48,net6.0,net8.0
removed tools/ folder from nupkg to reduce size